### PR TITLE
Add the ability to re-run another named report while in the report buffer

### DIFF
--- a/ledger-report.el
+++ b/ledger-report.el
@@ -123,6 +123,7 @@ reports to their location in the currrent ledger file buffer."
     (define-key map [?r] 'ledger-report-redo)
     (define-key map [(shift ?r)] 'ledger-report-reverse-report)
     (define-key map [?s] 'ledger-report-save)
+    (define-key map [(shift ?s)] 'ledger-report-select-report)
     (define-key map [?k] 'ledger-report-kill)
     (define-key map [?e] 'ledger-report-edit-report)
     (define-key map [( shift ?e)] 'ledger-report-edit-reports)
@@ -143,6 +144,7 @@ reports to their location in the currrent ledger file buffer."
 (easy-menu-define ledger-report-mode-menu ledger-report-mode-map
   "Ledger report menu"
   '("Reports"
+    ["Select Report" ledger-report-select-report]
     ["Save Report" ledger-report-save]
     ["Edit Current Report" ledger-report-edit-report]
     ["Edit All Reports" ledger-report-edit-reports]
@@ -434,6 +436,13 @@ Optional EDIT the command."
   "Edit the current report command in the mini buffer and re-run the report."
   (interactive)
   (setq ledger-report-cmd (ledger-report-read-command ledger-report-cmd))
+  (ledger-report-redo))
+
+(defun ledger-report-select-report ()
+  "Select and run one of the named reports."
+  (interactive)
+  (setq ledger-report-name (ledger-report-read-name)
+        ledger-report-cmd (ledger-report-cmd ledger-report-name nil))
   (ledger-report-redo))
 
 (defun ledger-report-read-new-name ()


### PR DESCRIPTION
This PR adds a small feature, allowing the user to run another named report while in the report buffer. This way, if you have a series of named reports you run regularly, you can cycle through them in the report buffer instead of going back to the ledger buffer and re-running a report from scratch.

It uses the `ledger-report-redo` machinery for compatibility, so it should set all of the required local variables.

I've used the key `S` for this (a mnemonic for "select"), but I'm open to other suggestions.