### PR TITLE
Add header in test.el files

### DIFF
--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -1,4 +1,26 @@
-;;; complete-test.el --- ERT for ledger-mode
+;;; complete-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-complete

--- a/test/context-test.el
+++ b/test/context-test.el
@@ -1,4 +1,26 @@
-;;; context-test.el --- ERT for ledger-mode
+;;; context-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-context

--- a/test/exec-test.el
+++ b/test/exec-test.el
@@ -1,4 +1,26 @@
-;;; exec-test.el --- ERT for ledger-mode
+;;; exec-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-exec

--- a/test/fontify-test.el
+++ b/test/fontify-test.el
@@ -1,4 +1,26 @@
-;;; fontify-test.el --- ERT for ledger-mode
+;;; fontify-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-fontify

--- a/test/mode-test.el
+++ b/test/mode-test.el
@@ -1,7 +1,29 @@
-;;; mode-test.el --- ERT for ledger-mode
+;;; mode-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
-;;  Regression tests for ledger-mode.el
+;;  Regression tests for ledger-mode
 
 ;;; Code:
 (require 'test-helper)

--- a/test/navigate-test.el
+++ b/test/navigate-test.el
@@ -1,4 +1,26 @@
-;;; navigate-test.el --- ERT for ledger-mode
+;;; navigate-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-navigate

--- a/test/occur-test.el
+++ b/test/occur-test.el
@@ -1,4 +1,26 @@
-;;; occur-test.el --- ERT for ledger-mode
+;;; occur-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-occur

--- a/test/post-test.el
+++ b/test/post-test.el
@@ -1,4 +1,26 @@
-;;; post-test.el --- ERT for ledger-mode
+;;; post-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-post

--- a/test/reconcile-test.el
+++ b/test/reconcile-test.el
@@ -1,4 +1,26 @@
-;;; reconcile-test.el --- ERT for ledger-mode
+;;; reconcile-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-reconcile

--- a/test/sort-test.el
+++ b/test/sort-test.el
@@ -1,4 +1,26 @@
-;;; sort-test.el --- ERT for ledger-mode
+;;; sort-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-sort

--- a/test/state-test.el
+++ b/test/state-test.el
@@ -1,4 +1,26 @@
-;;; state-test.el --- ERT for ledger-mode
+;;; state-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-state

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,4 +1,26 @@
-;;; test-helper.el --- ERT for ledger-mode
+;;; test-helper.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  ERT test helpers for ledger-mode

--- a/test/xact-test.el
+++ b/test/xact-test.el
@@ -1,4 +1,26 @@
-;;; xact-test.el --- ERT for ledger-mode
+;;; xact-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 ;;; Commentary:
 ;;  Regression tests for ledger-xact


### PR DESCRIPTION
Header is respecting conventions described in
"Conventional Headers for Emacs Libraries" at
https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html