### PR TITLE
Use ledger master file for balance at point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.6)
+
 set(EMACS_LISP_SOURCES
   ledger-check.el
   ledger-commodities.el

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(EMACS_LISP_SOURCES
+  ledger-check.el
   ledger-commodities.el
   ledger-complete.el
   ledger-exec.el

--- a/ledger-check.el
+++ b/ledger-check.el
@@ -32,6 +32,7 @@
   (require 'cl))
 
 (defvar ledger-check-buffer-name "*Ledger Check*")
+(defvar ledger-original-window-cfg nil)
 
 
 

--- a/ledger-check.el
+++ b/ledger-check.el
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (require 'easymenu)
+(require 'ledger-navigate)
 (eval-when-compile
   (require 'cl))
 

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -138,7 +138,7 @@ the balance into that."
   (interactive "P")
   (let* ((account (ledger-read-account-with-prompt "Account balance to show"))
          (target-commodity (when arg (ledger-read-commodity-with-prompt "Target commodity: ")))
-         (buffer (current-buffer))
+         (buffer (find-file-noselect (ledger-master-file)))
          (balance (with-temp-buffer
                     (apply 'ledger-exec-ledger buffer (current-buffer) "cleared" account
                            (when target-commodity (list "-X" target-commodity)))


### PR DESCRIPTION
In this pull request, we fix one build error when building on foreign directory (IOW: mkdir build && cd build && cmake ..), we also silence three build warnings. The actual important patch is the top-post in the series which lets us get correct balance-at-point even for those using several ledger files.