### PR TITLE
Simplify the usage of ledger-post-edit-amount

### DIFF
--- a/ledger-post.el
+++ b/ledger-post.el
@@ -186,12 +186,14 @@ regular text."
           (let ((val-string (match-string 0)))
             (goto-char (match-beginning 0))
             (delete-region (match-beginning 0) (match-end 0))
+            (push-mark)
             (calc)
             (calc-eval val-string 'push)) ;; edit the amount
         (progn ;;make sure there are two spaces after the account name and go to calc
           (if (search-backward "  " (- (point) 3) t)
               (goto-char (line-end-position))
             (insert "  "))
+          (push-mark)
           (calc))))))
 
 (provide 'ledger-post)


### PR DESCRIPTION
Hi,

Thanks for ledger-mode!


It's all in the commit message, I guess, which is:

 Push mark to simplify post-edit action

* ledger-post.el(ledger-post-edit-amount): Added (push-mark) before entering calc. This allows to finalize the post edit from the calc buffer using C-u y.


Best regards,  Marco

