### PR TITLE
Use cl-lib package rather than cl

### DIFF
--- a/ledger-check.el
+++ b/ledger-check.el
@@ -28,8 +28,8 @@
 
 (require 'easymenu)
 (require 'ledger-navigate)
-(eval-when-compile
-  (require 'cl))
+(require 'ledger-report) ; for ledger-master-file
+
 
 (defvar ledger-check-buffer-name "*Ledger Check*")
 (defvar ledger-original-window-cfg nil)

--- a/ledger-context.el
+++ b/ledger-context.el
@@ -25,9 +25,6 @@
 
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
-
 ;; ledger-*-string constants are assembled in the
 ;; `ledger-single-line-config' macro to form the regex and list of
 ;; elements

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -4,6 +4,8 @@
 
 ;; This file is not part of GNU Emacs.
 
+;; Package-Requires: ((emacs "24.3"))
+
 ;; This is free software; you can redistribute it and/or modify it under
 ;; the terms of the GNU General Public License as published by the Free
 ;; Software Foundation; either version 2, or (at your option) any later

--- a/ledger-occur.el
+++ b/ledger-occur.el
@@ -29,9 +29,7 @@
 
 ;;; Code:
 
-;; TODO: replace this with (require 'cl-lib)
-(with-no-warnings
-  (require 'cl))
+(require 'cl-lib)
 (require 'ledger-navigate)
 
 (defconst ledger-occur-overlay-property-name 'ledger-occur-custom-buffer-grep)
@@ -119,7 +117,7 @@ currently active."
   "Create the overlays for the visible transactions.
 Argument OVL-BOUNDS contains bounds for the transactions to be left visible."
   (let* ((beg (caar ovl-bounds))
-         (end (cadar ovl-bounds)))
+         (end (cl-cadar ovl-bounds)))
     (ledger-occur-remove-overlays)
     (ledger-occur-make-invisible-overlay (point-min) (1- beg))
     (dolist (visible (cdr ovl-bounds))
@@ -156,7 +154,7 @@ Argument OVL-BOUNDS contains bounds for the transactions to be left visible."
   (if buffer-matches
       (let ((points (list))
             (current-beginning (caar buffer-matches))
-            (current-end (cadar buffer-matches)))
+            (current-end (cl-cadar buffer-matches)))
         (dolist (match (cdr buffer-matches))
           (if (< (- (car match) current-end) 2)
               (setq current-end (cadr match))

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -399,7 +399,7 @@ POSTING is used in `ledger-clear-whole-transactions' is nil."
     (while (string-match "(\\(.*?\\))" fstr start)
       (setq fields (cons (intern (match-string 1 fstr)) fields))
       (setq start (match-end 0)))
-    (setq fields (list* 'format (replace-regexp-in-string "(.*?)" "" fstr) (nreverse fields)))
+    (setq fields (cl-list* 'format (replace-regexp-in-string "(.*?)" "" fstr) (nreverse fields)))
     `(lambda (date code status payee account amount)
        ,fields)))
 

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -20,9 +20,7 @@
 ;; MA 02110-1301 USA.
 
 (require 'rx)
-
-(eval-when-compile
-  (require 'cl))
+(require 'cl-lib)
 
 (defconst ledger-amount-regex
   (concat "\\(  \\|\t\\| \t\\)[ \t]*-?"
@@ -126,21 +124,21 @@
         (let (var grouping target)
           (if (symbolp arg)
               (setq var arg target arg)
-            (assert (listp arg))
+            (cl-assert (listp arg))
             (if (= 2 (length arg))
                 (setq var (car arg)
                       target (cadr arg))
               (setq var (car arg)
                     grouping (cadr arg)
-                    target (caddr arg))))
+                    target (cl-caddr arg))))
 
           (if (and last-group
                    (not (eq last-group (or grouping target))))
-              (incf addend
-                    (symbol-value
-                     (intern-soft (concat "ledger-regex-"
-                                          (symbol-name last-group)
-                                          "-group--count")))))
+              (cl-incf addend
+                       (symbol-value
+                        (intern-soft (concat "ledger-regex-"
+                                             (symbol-name last-group)
+                                             "-group--count")))))
           (nconc
            defs
            (list

--- a/ledger-schedule.el
+++ b/ledger-schedule.el
@@ -32,7 +32,7 @@
 
 
 (require 'ledger-init)
-(require 'cl-macs)
+(require 'cl-lib)
 
 (declare-function ledger-mode "ledger-mode")
 ;;; Code:
@@ -278,11 +278,11 @@ date descriptor."
   "Search CANDIDATE-ITEMS for xacts that occur within the period today - EARLY  to today + HORIZON."
   (let ((start-date (time-subtract (current-time) (days-to-time early)))
         test-date items)
-    (loop for day from 0 to (+ early horizon) by 1 do
-          (setq test-date (time-add start-date (days-to-time day)))
-          (dolist (candidate candidate-items items)
-            (if (funcall (car candidate) test-date)
-                (setq items (append items (list (list test-date (cadr candidate))))))))
+    (cl-loop for day from 0 to (+ early horizon) by 1 do
+             (setq test-date (time-add start-date (days-to-time day)))
+             (dolist (candidate candidate-items items)
+               (if (funcall (car candidate) test-date)
+                   (setq items (append items (list (list test-date (cadr candidate))))))))
     items))
 
 (defun ledger-schedule-create-auto-buffer (candidate-items early horizon ledger-buf)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -28,7 +28,7 @@
 ;;; Code:
 (require 'ledger-mode)
 (require 'ert)
-(require 'cl-macs) ; Common Lisp Macros
+(require 'cl-lib)
 
 (defvar demo-ledger)
 


### PR DESCRIPTION
Switching to `cl-lib` has been a to-do for a while. This PR makes the change, and also switches the travis build to evm and cask, which make cross-Emacs testing and package installation easy.

NOTE: I don't expect the travis build for this branch to work immediately, so this PR should be considered a work in progress.