### PR TITLE
Fix ledger-mode-clean-buffer not navigating back to where it started

### DIFF
--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -242,12 +242,12 @@ With a prefix argument, remove the effective date."
   (interactive)
   (let ((start (point-min-marker))
         (end (point-max-marker)))
-    (goto-char start)
     (ledger-navigate-beginning-of-xact)
     (beginning-of-line)
     (let ((target (buffer-substring (point) (progn
                                               (end-of-line)
                                               (point)))))
+      (goto-char start)
       (untabify start end)
       (ledger-sort-buffer)
       (ledger-post-align-postings start end)


### PR DESCRIPTION
Need to goto-char start later otherwise target just points to the first line, which isn't where point started (probably)