### PR TITLE
Fix group matching of `ledger-commoditized-amount-regexp`

### DIFF
--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -275,33 +275,41 @@
                       (kind account-kind)
                       (name account))
 
+(ledger-define-regexp commodity-no-group
+                      (rx (or (and ?\" (+ (not (any ?\"))) ?\")
+                              (not (any blank ?\n
+                                        digit
+                                        ?- ?\[ ?\]
+                                        ?. ?, ?\; ?+ ?* ?/ ?^ ?? ?: ?& ?| ?! ?=
+                                        ?\< ?\> ?\{ ?\} ?\( ?\) ?@))))
+                      "")
+
 (ledger-define-regexp commodity
-                      (rx (group
-                           (or (and ?\" (+ (not (any ?\"))) ?\")
-                               (not (any blank ?\n
-                                         digit
-                                         ?- ?\[ ?\]
-                                         ?. ?, ?\; ?+ ?* ?/ ?^ ?? ?: ?& ?| ?! ?=
-                                         ?\< ?\> ?\{ ?\} ?\( ?\) ?@)))))
+                      (macroexpand
+                       `(rx (group (regexp ,ledger-commodity-no-group-regexp))))
+                      "")
+
+(ledger-define-regexp amount-no-group
+                      (rx (and (? ?-)
+                               (and (+ digit)
+                                    (*? (and (any ?. ?,) (+ digit))))
+                               (? (and (any ?. ?,) (+ digit)))))
                       "")
 
 (ledger-define-regexp amount
-                      (rx (group
-                           (and (? ?-)
-                                (and (+ digit)
-                                     (*? (and (any ?. ?,) (+ digit))))
-                                (? (and (any ?. ?,) (+ digit))))))
+                      (macroexpand
+                       `(rx (group (regexp ,ledger-amount-no-group-regexp))))
                       "")
 
 (ledger-define-regexp commoditized-amount
                       (macroexpand
                        `(rx (group
-                             (or (and (regexp ,ledger-commodity-regexp)
+                             (or (and (regexp ,ledger-commodity-no-group-regexp)
                                       (*? blank)
-                                      (regexp ,ledger-amount-regexp))
-                                 (and (regexp ,ledger-amount-regexp)
+                                      (regexp ,ledger-amount-no-group-regexp))
+                                 (and (regexp ,ledger-amount-no-group-regexp)
                                       (*? blank)
-                                      (regexp ,ledger-commodity-regexp))))))
+                                      (regexp ,ledger-commodity-no-group-regexp))))))
                       "")
 
 (ledger-define-regexp commodity-annotations


### PR DESCRIPTION
When `ledger-context-at-point` is applied to:

```
    Expenses:Food:Dining                      £50.00  ;foobar
```

We obtain:

```
(acct-transaction account ((indent "   " 8664) (status nil nil) (account "Expenses:Food:Dining" 8668) (separator "                      " 8688) (commoditized-amount "£50.00" 8710) (separator "£" 8710) (comment "50.00" 8711)))
```

Notice that the match values for separator and comment are the sub-matches of commoditized-amount.  This patch creates no-group variants of the amount and commodity regexps so that they can be used in the commoditized amount regexp.  After this patch the match values are correct:

```
(acct-transaction account ((indent "   " 8664) (status nil nil) (account "Expenses:Food:Dining" 8668) (separator "                      " 8688) (commoditized-amount "£50.00" 8710) (separator "  " 8716) (comment "foobar" 8719)))
```