### PR TITLE
Only highlight current transaction if region is inactive

### DIFF
--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -56,8 +56,9 @@
       (let ((b (car exts))
             (e (cadr exts))
             (p (point)))
-        (if (and (> (- e b) 1)       ; not an empty line
-                 (<= p e) (>= p b))  ; point is within the boundaries
+        (if (and (> (- e b) 1)            ; not an empty line
+                 (<= p e) (>= p b)        ; point is within the boundaries
+                 (not (region-active-p))) ; no active region
             (move-overlay ledger-xact-highlight-overlay b (+ 1 e))
           (move-overlay ledger-xact-highlight-overlay 1 1))))))
 


### PR DESCRIPTION
This prevents the transaction highlight from interfering with the region
highlight, as for example in the following case:

```
<1>2017-01-01 * Test
    Expenses:A  $15
    Income:B

2017-01-01 * Test
    Expenses:A  $15
    Income:B
<0>
```

(Place point on <0>, then press C-SPC and move the point to <1>: note how
the transaction overlay takes precedence over the region overlay, which is undesirable)