### PR TITLE
Lexical bindings

### DIFF
--- a/ledger-check.el
+++ b/ledger-check.el
@@ -1,4 +1,4 @@
-;;; ledger-check.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-check.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015 Craig Earls (enderw88 AT gmail DOT com)
 

--- a/ledger-commodities.el
+++ b/ledger-commodities.el
@@ -1,4 +1,4 @@
-;;; ledger-commodities.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-commodities.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -1,4 +1,4 @@
-;;; ledger-complete.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-complete.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 
@@ -165,7 +165,7 @@ Looks in `ledger-accounts-file' if set, otherwise the current buffer."
 
 (defun ledger-complete-date (month-string day-string)
   "Complete a date."
-  (lexical-let*
+  (let*
       ((now (current-time))
        (decoded (decode-time now))
        (to-day (nth 3 decoded))
@@ -188,9 +188,9 @@ Looks in `ledger-accounts-file' if set, otherwise the current buffer."
 
 (defun ledger-complete-effective-date
     (tx-year-string tx-month-string tx-day-string
-     month-string day-string)
+                    month-string day-string)
   "Complete an effective date."
-  (lexical-let*
+  (let*
       ((tx-year (string-to-number tx-year-string))
        (tx-month (string-to-number tx-month-string))
        (tx-day (string-to-number tx-day-string))

--- a/ledger-context.el
+++ b/ledger-context.el
@@ -1,4 +1,4 @@
-;;; ledger-context.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-context.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-exec.el
+++ b/ledger-exec.el
@@ -1,4 +1,4 @@
-;;; ledger-exec.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-exec.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-fontify.el
+++ b/ledger-fontify.el
@@ -1,4 +1,4 @@
-;;; ledger-fontify.el --- Provide custom fontification for ledger-mode
+;;; ledger-fontify.el --- Provide custom fontification for ledger-mode  -*- lexical-binding: t; -*-
 
 
 ;; Copyright (C) 2014 Craig P. Earls (enderw88 at gmail dot com)

--- a/ledger-fonts.el
+++ b/ledger-fonts.el
@@ -1,4 +1,4 @@
-;;; ledger-fonts.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-fonts.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-init.el
+++ b/ledger-init.el
@@ -1,4 +1,4 @@
-;;; ledger-init.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-init.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -1,4 +1,4 @@
-;;; ledger-mode.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-mode.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-navigate.el
+++ b/ledger-navigate.el
@@ -1,4 +1,4 @@
-;;; ledger-navigate.el --- Provide navigation services through the ledger buffer.
+;;; ledger-navigate.el --- Provide navigation services through the ledger buffer.  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2014-2015 Craig Earls (enderw88 AT gmail DOT com)
 

--- a/ledger-occur.el
+++ b/ledger-occur.el
@@ -1,4 +1,4 @@
-;;; ledger-occur.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-occur.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-post.el
+++ b/ledger-post.el
@@ -1,4 +1,4 @@
-;;; ledger-post.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-post.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -1,4 +1,4 @@
-;;; ledger-reconcile.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-reconcile.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -1,4 +1,4 @@
-;;; ledger-regex.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-regex.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -1,4 +1,4 @@
-;;; ledger-report.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-report.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-schedule.el
+++ b/ledger-schedule.el
@@ -285,7 +285,7 @@ date descriptor."
                    (setq items (append items (list (list test-date (cadr candidate))))))))
     items))
 
-(defun ledger-schedule-create-auto-buffer (candidate-items early horizon ledger-buf)
+(defun ledger-schedule-create-auto-buffer (candidate-items early horizon)
   "Format CANDIDATE-ITEMS for display."
   (let ((candidates (ledger-schedule-list-upcoming-xacts candidate-items early horizon))
         (schedule-buf (get-buffer-create ledger-schedule-buffer-name)))
@@ -318,8 +318,7 @@ Use a prefix arg to change the default value"
         (ledger-schedule-create-auto-buffer
          (ledger-schedule-scan-transactions file)
          look-backward
-         look-forward
-         (current-buffer))
+         look-forward)
         (pop-to-buffer ledger-schedule-buffer-name))
     (error "Could not find ledger schedule file at %s" file)))
 

--- a/ledger-schedule.el
+++ b/ledger-schedule.el
@@ -1,4 +1,4 @@
-;;; ledger-schedule.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-schedule.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013 Craig Earls (enderw88 at gmail dot com)
 

--- a/ledger-sort.el
+++ b/ledger-sort.el
@@ -1,4 +1,4 @@
-;;; ledger-sort.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-sort.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-state.el
+++ b/ledger-state.el
@@ -1,4 +1,4 @@
-;;; ledger-state.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-state.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-texi.el
+++ b/ledger-texi.el
@@ -1,4 +1,4 @@
-;;; ledger-texi.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-texi.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 

--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -1,4 +1,4 @@
-;;; ledger-xact.el --- Helper code for use with the "ledger" command-line tool
+;;; ledger-xact.el --- Helper code for use with the "ledger" command-line tool  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2003-2016 John Wiegley (johnw AT gnu DOT org)
 


### PR DESCRIPTION
Prefer `lexical-binding t`

This started out as an attempt to fix a few compiler warnings, which I'll submit later. The compiler couldn't find `lexical-let*` as a function so I decided to remove it rather than require cl at compile