### PR TITLE
Add support for flymake in Emacs 26+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 matrix:
   allow_failures:
-    - env: EMACS=emacs-snapshot LEDGER_BRANCH=next
+    - env: EMACS_VERSION=emacs-snapshot LEDGER_BRANCH=next
 
 before_install:
   - ./tools/travis-install-ledger.sh $LEDGER_BRANCH

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ quick demo as well as more extensive documentation.
 Related packages
 ================
 
-In-buffer checking of formatting and balancing of transactions is
-available using [`flycheck-ledger`][flycheck-ledger].
+In-buffer checking of formatting and balancing of transactions is available
+built-in for Emacs version 26 and later using `flymake-mode`. For flycheck users
+(and users of Emacses earlier and 26), [`flycheck-ledger`][flycheck-ledger] is
+available.
 
 
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Related packages
 
 In-buffer checking of formatting and balancing of transactions is available
 built-in for Emacs version 26 and later using `flymake-mode`. For flycheck users
-(and users of Emacses earlier and 26), [`flycheck-ledger`][flycheck-ledger] is
+(and users of Emacs 25 and earlier), [`flycheck-ledger`][flycheck-ledger] is
 available.
 
 

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -27,6 +27,9 @@
 ;;; Code:
 (require 'cl-lib)
 (require 'ledger-exec)                  ; for `ledger-binary-path'
+(declare-function flymake-diag-region "flymake")
+(declare-function flymake-make-diagnostic "flymake")
+(declare-function flymake-log "flymake")
 
 (defvar-local ledger--flymake-proc nil)
 

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -21,7 +21,7 @@
 
 ;;; Commentary:
 ;; Flymake is the built-in Emacs package to support on-the-fly syntax checking.
-;; This file adds support for flymake to `ledger-mode'. Enable it by calling
+;; This file adds support for flymake to `ledger-mode'.  Enable it by calling
 ;; `flymake-mode' from a file-visiting ledger buffer.
 
 ;;; Code:
@@ -90,7 +90,7 @@ Flymake calls this with REPORT-FN as needed."
                       ;; of objects, and call `report-fn'.
                       (cl-loop
                        while (search-forward-regexp
-                              ;; This regex needs to match the whole error. We
+                              ;; This regex needs to match the whole error.  We
                               ;; also need a capture group for the error message
                               ;; (that's group 1 here) and the line number
                               ;; (group 2).

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (defvar-local ledger--flymake-proc nil)
+(defvar ledger-binary-path)
 
 ;; Based on the example from Flymake's info:
 (defun ledger-flymake (report-fn &rest _args)
@@ -100,7 +101,7 @@ Flymake calls this with REPORT-FN as needed."
               (kill-buffer (process-buffer proc))))))))))
 
 (defun ledger-enable-flymake ()
-  "Enable `flymake-mode' in ledger-mode buffers.
+  "Enable function `flymake-mode' in `ledger-mode' buffers.
 
 Don't enable flymake if flycheck is on and flycheck-ledger is
 available."

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -25,8 +25,7 @@
 ;; `flymake-mode' from a file-visiting ledger buffer.
 
 ;;; Code:
-(eval-when-compile
-  (require 'cl-lib))
+(require 'cl-lib)
 (require 'ledger-exec)                  ; for `ledger-binary-path'
 
 (defvar-local ledger--flymake-proc nil)

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -99,13 +99,22 @@ Flymake calls this with REPORT-FN as needed."
               ;; check's output.
               (kill-buffer (process-buffer proc))))))))))
 
+(defun ledger-enable-flymake ()
+  "Enable `flymake-mode' in ledger-mode buffers.
+
+Don't enable flymake if flycheck is on and flycheck-ledger is
+available."
+  (unless (and (featurep 'flycheck-ledger)
+               (bound-and-true-p flycheck-mode)))
+  (flymake-mode))
+
 ;; Automatically enable flymake in ledger-mode buffers when using Emacs 26+
 (when (<= 26 emacs-major-version)
   ;; Add `ledger-flymake' to `flymake-diagnostic-functions' so that flymake can
   ;; work in ledger-mode:
   (add-hook 'flymake-diagnostic-functions 'ledger-flymake nil t)
   ;; Enable it!
-  (add-hook 'ledger-mode-hook #'flymake-mode))
+  (add-hook 'ledger-mode-hook #'ledger-enable-flymake))
 
 (provide 'ledger-flymake)
 

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -70,8 +70,8 @@ Flymake calls this with REPORT-FN as needed."
         :name "ledger-flymake" :noquery t :connection-type 'pipe
         :buffer (generate-new-buffer " *ledger-flymake*")
         :command `(,ledger-binary-path "-f" ,file
-                                       (when ledger-flymake-be-pedantic "--pedantic")
-                                       (when ledger-flymake-be-explicit "--explicit")
+                                       ,(when ledger-flymake-be-pedantic "--pedantic")
+                                       ,(when ledger-flymake-be-explicit "--explicit")
                                        "balance")
         :sentinel
         (lambda (proc _event)

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -29,6 +29,20 @@
 (defvar-local ledger--flymake-proc nil)
 (defvar ledger-binary-path)
 
+(defcustom ledger-flymake-be-pedantic nil
+  "If non-nil, pass the --pedantic flag for ledger to the flymake backend.
+If --pedantic is in your ledgerrc file, then --pedantic gets
+passed regardless of the value."
+  :type 'boolean
+  :group 'ledger)
+
+(defcustom ledger-flymake-be-explicit nil
+  "If non-nil, pass the --explicit flag for ledger to the flymake backend.
+If --explicit is in your ledgerrc file, then --explicit gets
+passed regardless of the value."
+  :type 'boolean
+  :group 'ledger)
+
 ;; Based on the example from Flymake's info:
 (defun ledger-flymake (report-fn &rest _args)
   "A Flymake backend for `ledger-mode'.
@@ -55,7 +69,10 @@ Flymake calls this with REPORT-FN as needed."
        (make-process
         :name "ledger-flymake" :noquery t :connection-type 'pipe
         :buffer (generate-new-buffer " *ledger-flymake*")
-        :command `(,ledger-binary-path "-f" ,file "balance")
+        :command `(,ledger-binary-path "-f" ,file
+                                       (when ledger-flymake-be-pedantic "--pedantic")
+                                       (when ledger-flymake-be-explicit "--explicit")
+                                       "balance")
         :sentinel
         (lambda (proc _event)
           ;; Check that the process has indeed exited, as it might

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -85,9 +85,7 @@ Flymake calls this with REPORT-FN as needed."
                        for (beg . end) = (flymake-diag-region
                                           source
                                           (string-to-number (match-string 2)))
-                       for type = (if nil
-                                      :warning
-                                    :error)
+                       for type = :error
                        collect (flymake-make-diagnostic source
                                                         beg
                                                         end
@@ -102,7 +100,7 @@ Flymake calls this with REPORT-FN as needed."
               (kill-buffer (process-buffer proc))))))))))
 
 ;; Automatically enable flymake in ledger-mode buffers when using Emacs 26+
-(when (version<= "26" emacs-version)
+(when (<= 26 emacs-major-version)
   ;; Add `ledger-flymake' to `flymake-diagnostic-functions' so that flymake can
   ;; work in ledger-mode:
   (add-hook 'flymake-diagnostic-functions 'ledger-flymake nil t)

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -120,7 +120,7 @@ Flymake calls this with REPORT-FN as needed."
               (kill-buffer (process-buffer proc))))))))))
 
 (defun ledger-enable-flymake ()
-  "Enable function `flymake-mode' in `ledger-mode' buffers.
+  "Enable `flymake-mode' in `ledger-mode' buffers.
 
 Don't enable flymake if flycheck is on and flycheck-ledger is
 available."

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -25,9 +25,11 @@
 ;; `flymake-mode' from a file-visiting ledger buffer.
 
 ;;; Code:
+(eval-when-compile
+  (require 'cl-lib))
+(require 'ledger-exec)                  ; for `ledger-binary-path'
 
 (defvar-local ledger--flymake-proc nil)
-(defvar ledger-binary-path)
 
 (defcustom ledger-flymake-be-pedantic nil
   "If non-nil, pass the --pedantic flag for ledger to the flymake backend.

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -33,7 +33,7 @@
   "A Flymake backend for `ledger-mode'.
 
 Flymake calls this with REPORT-FN as needed."
-  (unless (executable-find "ledger")
+  (unless (executable-find ledger-binary-path)
     (error "Cannot find ledger"))
   ;; If a live process launched in an earlier check was found, that
   ;; process is killed.  When that process's sentinel eventually runs,
@@ -54,7 +54,7 @@ Flymake calls this with REPORT-FN as needed."
        (make-process
         :name "ledger-flymake" :noquery t :connection-type 'pipe
         :buffer (generate-new-buffer " *ledger-flymake*")
-        :command `("ledger" "-f" ,file "balance")
+        :command `(,ledger-binary-path "-f" ,file "balance")
         :sentinel
         (lambda (proc _event)
           ;; Check that the process has indeed exited, as it might

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -26,10 +26,8 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'flymake)
 (require 'ledger-exec)                  ; for `ledger-binary-path'
-(declare-function flymake-diag-region "flymake")
-(declare-function flymake-make-diagnostic "flymake")
-(declare-function flymake-log "flymake")
 
 (defvar-local ledger--flymake-proc nil)
 

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -107,13 +107,13 @@ Don't enable flymake if flycheck is on and flycheck-ledger is
 available."
   (unless (and (featurep 'flycheck-ledger)
                (bound-and-true-p flycheck-mode)))
+  ;; Add `ledger-flymake' to `flymake-diagnostic-functions' so that flymake can
+  ;; work in ledger-mode:
+  (add-hook 'flymake-diagnostic-functions 'ledger-flymake nil t)
   (flymake-mode))
 
 ;; Automatically enable flymake in ledger-mode buffers when using Emacs 26+
 (when (<= 26 emacs-major-version)
-  ;; Add `ledger-flymake' to `flymake-diagnostic-functions' so that flymake can
-  ;; work in ledger-mode:
-  (add-hook 'flymake-diagnostic-functions 'ledger-flymake nil t)
   ;; Enable it!
   (add-hook 'ledger-mode-hook #'ledger-enable-flymake))
 

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -126,6 +126,8 @@ Don't enable flymake if flycheck is on and flycheck-ledger is
 available."
   (unless (and (featurep 'flycheck-ledger)
                (bound-and-true-p flycheck-mode)))
+  (when (< 26 emacs-major-version)
+    (error "Ledger-flymake requires Emacs version 26 or higher"))
   ;; Add `ledger-flymake' to `flymake-diagnostic-functions' so that flymake can
   ;; work in ledger-mode:
   (add-hook 'flymake-diagnostic-functions 'ledger-flymake nil t)
@@ -133,7 +135,6 @@ available."
 
 ;; Automatically enable flymake in ledger-mode buffers when using Emacs 26+
 (when (<= 26 emacs-major-version)
-  ;; Enable it!
   (add-hook 'ledger-mode-hook #'ledger-enable-flymake))
 
 (provide 'ledger-flymake)

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -118,23 +118,18 @@ Flymake calls this with REPORT-FN as needed."
               ;; check's output.
               (kill-buffer (process-buffer proc))))))))))
 
-(defun ledger-enable-flymake ()
+;;;###autoload
+(defun ledger-flymake-enable ()
   "Enable `flymake-mode' in `ledger-mode' buffers.
 
 Don't enable flymake if flycheck is on and flycheck-ledger is
 available."
-  (unless (and (featurep 'flycheck-ledger)
-               (bound-and-true-p flycheck-mode)))
   (when (< 26 emacs-major-version)
     (error "Ledger-flymake requires Emacs version 26 or higher"))
   ;; Add `ledger-flymake' to `flymake-diagnostic-functions' so that flymake can
   ;; work in ledger-mode:
   (add-hook 'flymake-diagnostic-functions 'ledger-flymake nil t)
   (flymake-mode))
-
-;; Automatically enable flymake in ledger-mode buffers when using Emacs 26+
-(when (<= 26 emacs-major-version)
-  (add-hook 'ledger-mode-hook #'ledger-enable-flymake))
 
 (provide 'ledger-flymake)
 

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -1,0 +1,114 @@
+;;; ledger-flymake.el --- A ledger Flymake backend  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2018 J. Alexander Branham (alex DOT branham AT gmail DOT com)
+
+;; This file is not part of GNU Emacs.
+
+;; This is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free
+;; Software Foundation; either version 3, or (at your option) any later
+;; version.
+;;
+;; This is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+;; FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+;; for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+;; MA 02110-1301 USA.
+
+;;; Commentary:
+;; Flymake is the built-in Emacs package to support on-the-fly syntax checking.
+;; This file adds support for flymake to `ledger-mode'. Enable it by calling
+;; `flymake-mode' from a file-visiting ledger buffer.
+
+;;; Code:
+
+(defvar-local ledger--flymake-proc nil)
+
+;; Based on the example from Flymake's info:
+(defun ledger-flymake (report-fn &rest _args)
+  "A Flymake backend for `ledger-mode'.
+
+Flymake calls this with REPORT-FN as needed."
+  (unless (executable-find "ledger")
+    (error "Cannot find ledger"))
+  ;; If a live process launched in an earlier check was found, that
+  ;; process is killed.  When that process's sentinel eventually runs,
+  ;; it will notice its obsoletion, since it have since reset
+  ;; `ledger-flymake-proc' to a different value
+  (when (process-live-p ledger--flymake-proc)
+    (kill-process ledger--flymake-proc))
+  ;; Save the current buffer, the narrowing restriction, remove any
+  ;; narrowing restriction.
+  (let ((source (current-buffer))
+        (file (buffer-file-name)))
+    (save-restriction
+      (widen)
+      ;; Reset the `ledger--flymake-proc' process to a new process
+      ;; calling the ledger tool.
+      (setq
+       ledger--flymake-proc
+       (make-process
+        :name "ledger-flymake" :noquery t :connection-type 'pipe
+        :buffer (generate-new-buffer " *ledger-flymake*")
+        :command `("ledger" "-f" ,file "balance")
+        :sentinel
+        (lambda (proc _event)
+          ;; Check that the process has indeed exited, as it might
+          ;; be simply suspended.
+          (when (eq 'exit (process-status proc))
+            (unwind-protect
+                ;; Only proceed if `proc' is the same as
+                ;; `ledger--flymake-proc', which indicates that
+                ;; `proc' is not an obsolete process.
+                (if (with-current-buffer source (eq proc ledger--flymake-proc))
+                    (with-current-buffer (process-buffer proc)
+                      (goto-char (point-min))
+                      ;; Parse the output buffer for diagnostic's
+                      ;; messages and locations, collect them in a list
+                      ;; of objects, and call `report-fn'.
+                      (cl-loop
+                       while (search-forward-regexp
+                              ;; This regex needs to match the whole error. We
+                              ;; also need a capture group for the error message
+                              ;; (that's group 1 here) and the line number
+                              ;; (group 2).
+                              (rx line-start "While parsing file \"" (one-or-more (not whitespace)) " line " (group-n 2 (one-or-more num)) ":\n"
+                                  (zero-or-more line-start "While " (one-or-more not-newline) "\n" )
+                                  (minimal-match (zero-or-more line-start (zero-or-more not-newline) "\n"))
+                                  (group-n 1 "Error: " (one-or-more not-newline) "\n"))
+                              nil t)
+                       for msg = (match-string 1)
+                       for (beg . end) = (flymake-diag-region
+                                          source
+                                          (string-to-number (match-string 2)))
+                       for type = (if nil
+                                      :warning
+                                    :error)
+                       collect (flymake-make-diagnostic source
+                                                        beg
+                                                        end
+                                                        type
+                                                        msg)
+                       into diags
+                       finally (funcall report-fn diags)))
+                  (flymake-log :warning "Canceling obsolete check %s"
+                               proc))
+              ;; Cleanup the temporary buffer used to hold the
+              ;; check's output.
+              (kill-buffer (process-buffer proc))))))))))
+
+;; Automatically enable flymake in ledger-mode buffers when using Emacs 26+
+(when (version<= "26" emacs-version)
+  ;; Add `ledger-flymake' to `flymake-diagnostic-functions' so that flymake can
+  ;; work in ledger-mode:
+  (add-hook 'flymake-diagnostic-functions 'ledger-flymake nil t)
+  ;; Enable it!
+  (add-hook 'ledger-mode-hook #'flymake-mode))
+
+(provide 'ledger-flymake)
+
+;;; ledger-flymake.el ends here

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -53,6 +53,7 @@
 (require 'ledger-xact)
 (require 'ledger-schedule)
 (require 'ledger-check)
+(require 'ledger-flymake)
 
 ;;; Code:
 

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -53,7 +53,6 @@
 (require 'ledger-xact)
 (require 'ledger-schedule)
 (require 'ledger-check)
-(require 'ledger-flymake)
 
 ;;; Code:
 


### PR DESCRIPTION
Flymake, Emacs's built-in on-the-fly syntax checker, got a major
overhaul in Emacs 26. This means we can get built-in syntax checking
without requiring users to install both flycheck.el and
flycheck-ledger.el. The checking is done via `ledger balance`. Things
to keep in mind that as of now (the initial implementation):

- It will honor settings from users ~/.ledgerrc files (I'm not sure if
  this is a good thing or a bad thing)

- ~It will error if Emacs can't find ledger (i.e. if (executable-find
  "ledger") fails)~ Now uses `ledger-binary-path`

- ~There is no way yet to customize calls (using --pedantic, for
  example), though this would be easy to implement in the future~ Supports `--pedantic` and `--explicit`