### PR TITLE
Fixes for the byte compiler

### DIFF
--- a/ledger-check.el
+++ b/ledger-check.el
@@ -119,8 +119,7 @@ commands for navigating the buffer to the errors found, etc."
      (when (and (buffer-modified-p)
                 (y-or-n-p "Buffer modified, save it? "))
        (save-buffer))))
-  (let ((buf (find-file-noselect (ledger-master-file)))
-        (cbuf (get-buffer ledger-check-buffer-name))
+  (let ((cbuf (get-buffer ledger-check-buffer-name))
         (wcfg (current-window-configuration)))
     (if cbuf
         (kill-buffer cbuf))

--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -111,8 +111,7 @@ Looks in `ledger-accounts-file' if set, otherwise the current buffer."
 
 (defun ledger-find-accounts-in-buffer ()
   (interactive)
-  (let (accounts
-        (account-tree (list t))
+  (let ((account-tree (list t))
         (account-elements nil)
         (prefix (or (car pcomplete-args) "")))
     (save-excursion
@@ -168,7 +167,6 @@ Looks in `ledger-accounts-file' if set, otherwise the current buffer."
   (let*
       ((now (current-time))
        (decoded (decode-time now))
-       (to-day (nth 3 decoded))
        (this-month (nth 4 decoded))
        (this-year (nth 5 decoded))
        (last-month (if (> this-month 1) (1- this-month) 12))

--- a/ledger-fontify.el
+++ b/ledger-fontify.el
@@ -37,7 +37,7 @@
   :type 'boolean
   :group 'ledger)
 
-(defun ledger-fontify-buffer-part (&optional beg end len)
+(defun ledger-fontify-buffer-part (&optional beg end _len)
   "Fontify buffer from BEG to END, length LEN."
   (save-excursion
     (unless beg (setq beg (point-min)))
@@ -105,7 +105,7 @@ Fontify the first line of an xact"
                                      (match-end 4)) 'ledger-font-comment-face))
     (forward-line)))
 
-(defun ledger-fontify-posting (pos)
+(defun ledger-fontify-posting (_pos)
   "Fontify the posting at POS."
   (let* ((state nil)
          (end-of-line-comment nil)

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -89,7 +89,7 @@
   "\\(^[ \t]+\\)\\(*\\s-*[^ ].*?\\)\\(  \\|\t\\|$\\)")
 
 
-(defmacro ledger-define-regexp (name regex docs &rest args)
+(defmacro ledger-define-regexp (name regex _docs &rest args)
   "Simplify the creation of a Ledger regex and helper functions."
   (let ((defs
           (list

--- a/ledger-texi.el
+++ b/ledger-texi.el
@@ -38,8 +38,7 @@
 (defun ledger-update-test ()
   (interactive)
   (goto-char (point-min))
-  (let ((command (buffer-substring (point-min) (line-end-position)))
-        input)
+  (let ((command (buffer-substring (point-min) (line-end-position))))
     (re-search-forward "^<<<\n")
     (let ((beg (point)) end)
       (re-search-forward "^>>>")
@@ -133,7 +132,7 @@
     (while (re-search-forward "^@c \\(\\(?:sm\\)?ex\\) \\(\\S-+\\): \\(.*\\)" nil t)
       (let ((section (match-string 1))
             (example-name (match-string 2))
-            (command (match-string 3)) expanded-command
+            (command (match-string 3))
             (data-file ledger-texi-sample-doc-path)
             input output)
         (goto-char (match-end 0))

--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -86,7 +86,7 @@ MOMENT is an encoded date"
     (catch 'found
       (ledger-xact-iterate-transactions
        (function
-        (lambda (start date mark desc)
+        (lambda (start date _mark _desc)
           (setq last-xact-start start)
           (if (ledger-time-less-p moment date)
               (throw 'found t))))))
@@ -111,7 +111,6 @@ MOMENT is an encoded date"
                   (month (string-to-number (match-string 5)))
                   (day (string-to-number (match-string 6)))
                   (mark (match-string 7))
-                  (code (match-string 8))
                   (desc (match-string 9)))
               (if (and year (> (length year) 0))
                   (setq year (string-to-number year)))
@@ -122,11 +121,12 @@ MOMENT is an encoded date"
       (forward-line))))
 
 (defun ledger-copy-transaction-at-point (date)
-  "Ask for a new DATE and copy the transaction under point to that date.  Leave point on the first amount."
+  "Ask for a new DATE and copy the transaction under point to that date.
+Leave point on the first amount."
   (interactive  (list
                  (ledger-read-date "Copy to date: ")))
   (let* ((here (point))
-         (extents (ledger-navigate-find-xact-extents (point)))
+         (extents (ledger-navigate-find-xact-extents here))
          (transaction (buffer-substring-no-properties (car extents) (cadr extents)))
          (encoded-date (ledger-parse-iso-date date)))
     (ledger-xact-find-slot encoded-date)
@@ -174,8 +174,7 @@ correct chronological place in the buffer."
   (let* ((args (with-temp-buffer
                  (insert transaction-text)
                  (eshell-parse-arguments (point-min) (point-max))))
-         (ledger-buf (current-buffer))
-         exit-code)
+         (ledger-buf (current-buffer)))
     (unless insert-at-point
       (let* ((date (car args))
              (parsed-date (ledger-parse-iso-date date)))


### PR DESCRIPTION
Most of these are new warnings from the switch to lexical-binding in 6c2e8bdf