### PR TITLE
Remove ledger-report-kill keybindings

### DIFF
--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -273,7 +273,7 @@ With a prefix argument, remove the effective date."
     (define-key map [(control ?c) (control ?o) (control ?a)] 'ledger-report-redo)
     (define-key map [(control ?c) (control ?o) (control ?e)] 'ledger-report-edit)
     (define-key map [(control ?c) (control ?o) (control ?g)] 'ledger-report-goto)
-    (define-key map [(control ?c) (control ?o) (control ?k)] 'ledger-report-kill)
+    (define-key map [(control ?c) (control ?o) (control ?k)] 'ledger-report-quit)
     (define-key map [(control ?c) (control ?o) (control ?r)] 'ledger-report)
     (define-key map [(control ?c) (control ?o) (control ?s)] 'ledger-report-save)
 
@@ -321,7 +321,7 @@ With a prefix argument, remove the effective date."
     ["Re-run Report" ledger-report-redo ledger-works]
     ["Save Report" ledger-report-save ledger-works]
     ["Edit Report" ledger-report-edit ledger-works]
-    ["Kill Report" ledger-report-kill ledger-works]))
+    ["Quit Report" ledger-report-quit ledger-works]))
 
 ;;;###autoload
 (define-derived-mode ledger-mode text-mode "Ledger"

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -164,7 +164,6 @@ Calls `shrink-window-if-larger-than-buffer'."
     (define-key map [(shift ?r)] 'ledger-report-reverse-report)
     (define-key map [?s] 'ledger-report-save)
     (define-key map [(shift ?s)] 'ledger-report-select-report)
-    (define-key map [?k] 'ledger-report-kill)
     (define-key map [?e] 'ledger-report-edit-report)
     (define-key map [( shift ?e)] 'ledger-report-edit-reports)
     (define-key map [?q] 'ledger-report-quit)
@@ -173,8 +172,6 @@ Calls `shrink-window-if-larger-than-buffer'."
       'ledger-report-redo)
     (define-key map [(control ?c) (control ?l) (control ?S)]
       'ledger-report-save)
-    (define-key map [(control ?c) (control ?l) (control ?k)]
-      'ledger-report-kill)
     (define-key map [(control ?c) (control ?l) (control ?e)]
       'ledger-report-edit)
     map)
@@ -520,6 +517,8 @@ arguments returned by `ledger-report--compute-extra-args'."
   (ledger-report-goto)
   (set-window-configuration ledger-original-window-cfg)
   (kill-buffer (get-buffer ledger-report-buffer-name)))
+
+(define-obsolete-function-alias 'ledger-report-kill #'ledger-report-quit)
 
 (defun ledger-report-edit-reports ()
   "Edit the defined ledger reports."


### PR DESCRIPTION
The function isn't defined anywhere so these all produce errors. I
re-define the function as an obsolete alias for ledger-report-quit and
replace the keybindings.