### PR TITLE
Fix a regexp in ledger-report--cmd-needs-links-p

### DIFF
--- a/ledger-report.el
+++ b/ledger-report.el
@@ -371,7 +371,7 @@ See documentation for the function `ledger-master-file'")
   "Check links should be added to the report produced by CMD."
   ;; --subtotal reports do not produce identifiable transactions, so
   ;; don't prepend location information for them
-  (and (string-match " reg\\(ister\\)? " cmd)
+  (and (string-match "\\<reg\\(ister\\)?\\>" cmd)
        ledger-report-links-in-register
        (not (string-match "--subtotal" cmd))))
 


### PR DESCRIPTION
A command like 'ledger reg' does not include a final space, and thus wouldn't
get links.  This bug was surfaced by e098be20cf603f48dfe18c6237546a8c49e1f97c.