### PR TITLE
schedule: maintain order of same date transactions in output

### DIFF
--- a/ledger-schedule.el
+++ b/ledger-schedule.el
@@ -291,7 +291,7 @@ date descriptor."
         (schedule-buf (get-buffer-create ledger-schedule-buffer-name)))
     (with-current-buffer schedule-buf
       (erase-buffer)
-      (dolist (candidate candidates)
+      (dolist (candidate (reverse candidates))
         (insert (ledger-format-date (car candidate) ) " " (cadr candidate) "\n"))
       (ledger-mode))
     (length candidates)))


### PR DESCRIPTION
Transaction that were scheduled on the same date had their order reversed in the
schedule buffer compared to their order in the schedule file.

This commit maintains the order defined in the schedule file.