### PR TITLE
Make ledger-binary-path risky

### DIFF
--- a/ledger-exec.el
+++ b/ledger-exec.el
@@ -43,6 +43,7 @@
 (defcustom ledger-binary-path "ledger"
   "Path to the ledger executable."
   :type 'file
+  :risky t
   :group 'ledger-exec)
 
 (defun ledger-exec-handle-error (ledger-errfile)


### PR DESCRIPTION
`ledger-binary-path` should be risky so people can't be tricked into running a malicious executable via a file-local variable setting. 