### PR TITLE
regex for effective date added

### DIFF
--- a/ledger-context.el
+++ b/ledger-context.el
@@ -39,7 +39,7 @@
 (defconst ledger-balance-assertion-string ledger-balance-assertion-regexp)
 (defconst ledger-comment-string "[ \t]*;[ \t]*\\(.*?\\)")
 (defconst ledger-nil-string "\\([ \t]+\\)")
-(defconst ledger-date-string "^\\([0-9]\\{4\\}[/-][01]?[0-9][/-][0123]?[0-9]\\)")
+(defconst ledger-date-string "^\\([0-9]\\{4\\}[/-][01]?[0-9][/-][0123]?[0-9]\\(?:=[0-9]\\{4\\}[/-][01]?[0-9][/-][0123]?[0-9]\\)?\\)")
 (defconst ledger-code-string "\\((.*)\\)?")
 (defconst ledger-payee-string "\\(.*[^[:space:]]\\)")
 


### PR DESCRIPTION
A slight addition to the date regex so that date strings that include an effective date match.

This came up because I wanted to be able to run the "payee" report on transactions that have an effective date in addition to the transaction date.  I think it works, but it's worth looking over by someone with more experience with this code.

I'm happy to try again if it doesn't work.

Respectfully submitted,
-James