### PR TITLE
Fix account-recognizing regular expressions

### DIFF
--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -72,15 +72,20 @@
   "^--.+?\\($\\|[ ]\\)")
 
 (defconst ledger-account-directive-regex
-  "^account [ \t]*\\(?2:.+?\\)\\(?3:[ \t]*\\)$")
+  "^account [ \t]*\\(?2:[^;]+?\\)\\(?3:[ \t]*\\)\\(;.*\\)?$")
+
+(defconst ledger-account-any-status-no-trailing-spaces-regex
+  "^[ \t]+\\(?1:[*!]\\s-+\\)?[[(]?\\(?2:[^; ].+?\\)[])]?")
 
 (defconst ledger-account-any-status-regex
-  "^[ \t]+\\(?1:[*!]\\s-+\\)?\\(?2:[[(]?[^ ].+?\\)\\(?3:\t\\|\n\\| [ \t]\\)")
+  (format "%s%s"
+          ledger-account-any-status-no-trailing-spaces-regex
+          "\\(?3:\t\\| [ \t]\\|$\\)"))
 
 (defconst ledger-account-name-or-directive-regex
-  (format "\\(?:%s\\|%s\\)"
+  (format "\\(?:%s\\|%s\\(?3:\t\\| [ \t]\\)\\)"
           ledger-account-directive-regex
-          ledger-account-any-status-regex))
+          ledger-account-any-status-no-trailing-spaces-regex))
 
 (defconst ledger-account-pending-regex
   "\\(^[ \t]+\\)\\(!\\s-*[^ ].*?\\)\\(  \\|\t\\|$\\)")

--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -81,6 +81,37 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=252"
     account2
 "))))
 
+(ert-deftest ledger-complete/test-find-accounts-in-buffer ()
+  (let ((ledger "*** Expenses
+account Expenses:Accomodation
+account Assets:Cash  ; some comment
+account Assets:Current
+    alias 1187465S022
+commodity EUR
+    format 1,000.00 EUR
+tag ofxid
+2018/05/07 * Company
+    Assets:Current  -38.33 EUR
+    ; ofxid: someid
+    Expenses:Utilities:Insurance  38.00 EUR
+    [Dimensions:Foo]  30.00 EUR
+    [Expenses:Accomodation]  8.33 EUR
+    [Dimensions:Equity]  -38.33 EUR
+    (Something)  43.00 EUR
+"))
+    (with-temp-buffer
+      (insert ledger)
+      (should (equal
+               (ledger-accounts-list-in-buffer)
+               (list ; I don't know why accounts are sorted in reverse order
+                "Something"
+                "Expenses:Utilities:Insurance"
+                "Expenses:Accomodation"
+                "Dimensions:Foo"
+                "Dimensions:Equity"
+                "Assets:Current"
+                "Assets:Cash"))))))
+
 
 (provide 'complete-test)
 


### PR DESCRIPTION
- exclude comments from being recognized as accounts
- remove [] and () from account names in virtual postings

Add a unit test to check that all account references and only those are detected.

To do the above, I had to fix ledger-post-align-postings which previously only working because comment lines were considered accounts.