### PR TITLE
Silence the byte compiler

### DIFF
--- a/ledger-fontify.el
+++ b/ledger-fontify.el
@@ -32,6 +32,10 @@
 (require 'ledger-regex)
 (require 'ledger-state)
 
+;; These are dynamically bound, see `font-lock-extend-region-functions'.
+(defvar font-lock-beg)
+(defvar font-lock-end)
+
 (defcustom ledger-fontify-xact-state-overrides nil
   "If t the highlight entire xact with state."
   :type 'boolean

--- a/ledger-fonts.el
+++ b/ledger-fonts.el
@@ -29,6 +29,7 @@
 (require 'ledger-navigate)
 (require 'ledger-regex)
 (require 'ledger-state)
+(require 'ledger-fontify)
 
 (defgroup ledger-faces nil "Ledger mode highlighting" :group 'ledger)
 


### PR DESCRIPTION
- Declare two variables used by multiline font-lock
- Require ledger-fontify in ledger-fonts for ledger-fontify-xact-state-overrides