### PR TITLE
 Add ledger-copy-transaction-insert-blank-line-after

### DIFF
--- a/doc/ledger-mode.texi
+++ b/doc/ledger-mode.texi
@@ -328,6 +328,10 @@ An easy way to copy a transaction is to type @kbd{C-c C-k} or menu entry
 copied transaction, and after having confirmed with @kbd{RET}, new
 transaction will be inserted at @emph{date} position in buffer.
 
+If you prefer to keep blank lines between your transactions, you can
+change the default in
+@option{ledger-copy-transaction-insert-blank-line-after}.
+
 @node Editing Amounts, Marking Transactions, Copying Transactions, The Ledger Buffer
 @section Editing Amounts
 @kindex C-c C-b

--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -132,7 +132,7 @@ MOMENT is an encoded date"
          (encoded-date (ledger-parse-iso-date date)))
     (ledger-xact-find-slot encoded-date)
     (insert transaction
-            (if (bound-and-true-p ledger-copy-transaction-insert-blank-line-after)
+            (if ledger-copy-transaction-insert-blank-line-after
                 "\n\n"
               "\n"))
     (beginning-of-line -1)

--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -120,6 +120,9 @@ MOMENT is an encoded date"
                        mark desc)))))
       (forward-line))))
 
+(defvar ledger-copy-transaction-insert-blank-line-after nil
+  "Non-nil means insert blank line after a transaction inserted with ‘ledger-copy-transaction-at-point’.")
+
 (defun ledger-copy-transaction-at-point (date)
   "Ask for a new DATE and copy the transaction under point to that date.  Leave point on the first amount."
   (interactive  (list
@@ -128,7 +131,10 @@ MOMENT is an encoded date"
          (transaction (buffer-substring-no-properties (car extents) (cadr extents)))
          (encoded-date (ledger-parse-iso-date date)))
     (ledger-xact-find-slot encoded-date)
-    (insert transaction "\n")
+    (insert transaction
+            (if (bound-and-true-p ledger-copy-transaction-insert-blank-line-after)
+                "\n\n"
+              "\n"))
     (beginning-of-line -1)
     (ledger-navigate-beginning-of-xact)
     (re-search-forward ledger-iso-date-regexp)


### PR DESCRIPTION
Hello,

I’ve written a small patch to add the possibility for user to insert a blank line after a transaction inserted with `ledger-copy-transaction-at-point`. The default behaviour only inserted a single `\n` after the transaction, which required manual fixing every time a transaction was to be copied.
I’ve also updated the manual to mention the variable in the relevant node (*Copying Transactions, Editing Amounts, Adding Transactions, The Ledger Buffer*).

I’m not sure if the Elisp is as good as it could be, nor if it flouts any convention I may not know, but I’m not very advanced with the language or with coding in general (although I do hope to improve).

(I’m still very new to the concept of contributing to projects and to opening pull requests, so please excuse me if I’ve done anything wrong, and thank you for bearing with me whilst I figure the ins and outs.)