### PR TITLE
Fixed flymake backend error

### DIFF
--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -72,8 +72,8 @@ Flymake calls this with REPORT-FN as needed."
         :name "ledger-flymake" :noquery t :connection-type 'pipe
         :buffer (generate-new-buffer " *ledger-flymake*")
         :command `(,ledger-binary-path "-f" ,file
-                                       ,(when ledger-flymake-be-pedantic "--pedantic")
-                                       ,(when ledger-flymake-be-explicit "--explicit")
+                                       ,(if ledger-flymake-be-pedantic "--pedantic" "")
+                                       ,(if ledger-flymake-be-explicit "--explicit" "")
                                        "balance")
         :sentinel
         (lambda (proc _event)


### PR DESCRIPTION
The `make-process` commands only accepts a list of strings but when
`ledger-flymake-be-pedantic` and/or `ledger-flymake-be-explicit` is not set to
true it will fail as that list now contains nil. Changed it to just return an
empty string when a setting isn't enabled.

Edit: Fixed quotes in markdown