### PR TITLE
Cleaner fix for the flymake backend.

### DIFF
--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -71,10 +71,12 @@ Flymake calls this with REPORT-FN as needed."
        (make-process
         :name "ledger-flymake" :noquery t :connection-type 'pipe
         :buffer (generate-new-buffer " *ledger-flymake*")
-        :command `(,ledger-binary-path "-f" ,file
-                                       ,(if ledger-flymake-be-pedantic "--pedantic" "")
-                                       ,(if ledger-flymake-be-explicit "--explicit" "")
-                                       "balance")
+        :command (cl-remove
+                  nil
+                  `(,ledger-binary-path "-f" ,file
+                                        ,(when ledger-flymake-be-pedantic "--pedantic")
+                                        ,(when ledger-flymake-be-explicit "--explicit")
+                                        "balance"))
         :sentinel
         (lambda (proc _event)
           ;; Check that the process has indeed exited, as it might


### PR DESCRIPTION
Removing the `nil` entries in the command list instead of setting them to empty
strings. As empty strings might mess with the command.

This cleaner and safer compared to the fix in #155. 