### PR TITLE
* doc/ledger-mode.texi: Change dircategory to Emacs

### DIFF
--- a/doc/ledger-mode.texi
+++ b/doc/ledger-mode.texi
@@ -47,7 +47,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 @end copying
 
-@dircategory Major Modes
+@dircategory Emacs
 @direntry
 * Ledger Mode: (ledger-mode).           Command-Line Accounting
 @end direntry


### PR DESCRIPTION
All the other Emacs major modes I have installed have "Emacs" as the dircategory. This makes ledger-mode respect that convention.