### PR TITLE
ledger-add-transaction: On new transaction, leave point after date

### DIFF
--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -200,8 +200,8 @@ correct chronological place in the buffer."
              (buffer-string))
            separator))
       (progn
-        (insert (car args) " \n" separator)
-        (end-of-line -1)))))
+        (insert (car args) " ")
+        (save-excursion (insert "\n" separator))))))
 
 (provide 'ledger-xact)
 


### PR DESCRIPTION
Fixes the regression pointed out by @ShuguangSun [in comments to #134](https://github.com/ledger/ledger-mode/pull/134#issuecomment-475467120).