### PR TITLE
Remove blank lines after ledger-delete-current-transaction

### DIFF
--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -161,7 +161,8 @@ MOMENT is an encoded date"
   "Delete the transaction surrounging POS."
   (interactive "d")
   (let ((bounds (ledger-navigate-find-xact-extents pos)))
-    (delete-region (car bounds) (cadr bounds))))
+    (delete-region (car bounds) (cadr bounds)))
+  (delete-blank-lines))
 
 (defvar ledger-add-transaction-last-date nil
   "Last date entered using `ledger-read-transaction'.")

--- a/test/reconcile-test.el
+++ b/test/reconcile-test.el
@@ -716,7 +716,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=262"
       (should ;; Expected: this must be ledger buffer
        (equal (buffer-name)           ; current buffer name
               (buffer-name ledger-buffer)))
-      (should (= 1323 (point))))))    ; expected on "Book Store" xact
+      (should (= 1321 (point))))))    ; expected on "Book Store" xact
 
 
 (ert-deftest ledger-reconcile/test-028 ()


### PR DESCRIPTION
Otherwise when we delete a transaction between two transactions, we're
left with a few blank lines instead of just one.