### PR TITLE
Don't kill the report buffer on every new report

### DIFF
--- a/ledger-report.el
+++ b/ledger-report.el
@@ -273,10 +273,10 @@ used to generate the buffer, navigating the buffer, etc."
          (buf (find-file-noselect file))
          (rbuf (get-buffer ledger-report-buffer-name))
          (wcfg (current-window-configuration)))
-    (if rbuf
-        (kill-buffer rbuf))
     (with-current-buffer
         (pop-to-buffer (get-buffer-create ledger-report-buffer-name))
+      (let ((inhibit-read-only t))
+        (erase-buffer))
       (ledger-report-mode)
       (set (make-local-variable 'ledger-report-saved) nil)
       (set (make-local-variable 'ledger-buf) buf)


### PR DESCRIPTION
Erase the report buffer rather than killing it and recreating it. This
allows users to use functions like `display-buffer-reuse-window' to
manager where the ledger-report buffer shows up.