### PR TITLE
New commands ledger-navigate-{next/previous}-uncleared

### DIFF
--- a/doc/ledger-mode.texi
+++ b/doc/ledger-mode.texi
@@ -249,6 +249,7 @@ current regex.  Cancel the narrowing by typing @kbd{C-c C-f} again.
 @chapter The Ledger Buffer
 
 @menu
+* Navigating Transactions::
 * Adding Transactions::
 * Copying Transactions::
 * Editing Amounts::
@@ -259,8 +260,28 @@ current regex.  Cancel the narrowing by typing @kbd{C-c C-f} again.
 * Narrowing Transactions::
 @end menu
 
+@node Navigating Transactions, Adding Transactions, The Ledger Buffer, The Ledger Buffer
+@section Navigating Transactions
+@cindex transaction, navigation
 
-@node Adding Transactions, Copying Transactions, The Ledger Buffer, The Ledger Buffer
+@findex ledger-navigate-next-xact-or-directive
+@findex ledger-navigate-prev-xact-or-directive
+@kindex M-p
+@kindex M-n
+
+In addition to the usual Emacs navigation commands, ledger-mode offers several
+additional commands to ease navigation. @kbd{M-n} and @kbd{M-p} navigate between
+next and previous xacts or directives.
+
+@findex ledger-navigate-next-uncleared
+@findex ledger-navigate-previous-uncleared
+
+Additionally, M-x ledger-navigate-previous-uncleared and M-x
+ledger-navigate-next-uncleared navigate to the next and precious uncleared
+transactions.
+
+
+@node Adding Transactions, Copying Transactions, Navigating Transactions, The Ledger Buffer
 @section Adding Transactions
 @findex ledger-post-amount-alignment-column
 @kindex TAB

--- a/ledger-navigate.el
+++ b/ledger-navigate.el
@@ -173,6 +173,26 @@ Requires empty line separating xacts."
         (ledger-navigate-find-xact-extents pos)
       (ledger-navigate-find-directive-extents pos))))
 
+(defun ledger-navigate-next-uncleared ()
+  "Move point to the next uncleared transaction."
+  (interactive)
+  (when (looking-at ledger-payee-uncleared-regex)
+    (forward-line))
+  (if (re-search-forward ledger-payee-uncleared-regex nil t)
+      (progn (beginning-of-line)
+             (point))
+    (user-error "No next uncleared transactions")))
+
+(defun ledger-navigate-previous-uncleared ()
+  "Move point to the previous uncleared transaction."
+  (interactive)
+  (when (equal (car (ledger-context-at-point)) 'acct-transaction)
+    (ledger-navigate-beginning-of-xact))
+  (if (re-search-backward ledger-payee-uncleared-regex nil t)
+      (progn (beginning-of-line)
+             (point))
+    (user-error "No previous uncleared transactions")))
+
 
 (provide 'ledger-navigate)
 

--- a/test/navigate-test.el
+++ b/test/navigate-test.el
@@ -43,6 +43,34 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=441"
    (ledger-navigate-prev-xact-or-directive)
    (should (eq 104 (point)))))
 
+(ert-deftest ledger-navigate-uncleared ()
+  :tags '(navigate)
+  (with-temp-buffer
+    (insert
+     "2011/01/27 Book Store
+    Expenses:Books                       $20.00
+    Liabilities:MasterCard
+
+2011/04/25 * Tom's Used Cars
+    Expenses:Auto                    $ 5,500.00
+    Assets:Checking
+
+2011/04/27 Bookstore
+    Expenses:Books                       $20.00
+    Assets:Checking
+
+2011/12/01 * Sale
+    Assets:Checking                     $ 30.00
+    Income:Sales")
+    (ledger-mode)
+    (goto-char (point-min))
+    (ledger-navigate-next-uncleared)
+    (should (looking-at-p (regexp-quote "2011/04/27 Bookstore")))
+    (should-error (ledger-navigate-next-uncleared))
+    (ledger-navigate-previous-uncleared)
+    (should (bobp))
+    ))
+
 
 (provide 'navigate-test)
 


### PR DESCRIPTION
These are two commands I use quite often to help me navigate between uncleared transactions. If people think they're useful enough to include in ledger-mode, I'm happy to write up documentation and some tests.