### PR TITLE
Add a way to filter account list for completion

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -41,3 +41,7 @@ how to use this.
 New commands ledger-navigate-next-uncleared and
 ledger-navigate-previous-uncleared move to the next and previous uncleared
 transactions. These don't have default keybindings.
+** New option ledger-accounts-exclude-function
+This allows users to exclude some accounts from being offered during completion.
+This is useful if, for example, you have a lot of accounts but only use some of
+them rarely.

--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -37,6 +37,14 @@ This file will then be used as a source for account name completions."
   :type 'file
   :group 'ledger)
 
+(defcustom ledger-accounts-exclude-function nil
+  "Function to exclude accounts from completion.
+Should be a predicate function that accepts one argument, an
+element of `ledger-accounts-list-in-buffer'."
+  :type 'function
+  :group 'ledger
+  :package-version '(ledger-mode . "2019-08-14"))
+
 (defcustom ledger-complete-in-steps nil
   "When non-nil, `ledger-complete-at-point' completes account names in steps.
 If nil, full account names are offered for completion."
@@ -149,7 +157,10 @@ Then one of the elements this function returns will be
 (defun ledger-accounts-list-in-buffer ()
   "Return a list of all known account names in the current buffer as strings.
 Considers both accounts listed in postings and those declared with \"account\" directives."
-  (mapcar #'car (ledger-accounts-in-buffer)))
+  (let ((accounts (ledger-accounts-in-buffer)))
+    (when ledger-accounts-exclude-function
+      (setq accounts (cl-remove-if ledger-accounts-exclude-function accounts)))
+    (mapcar #'car accounts)))
 
 (defun ledger-accounts-list ()
   "Return a list of all known account names as strings.

--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -164,6 +164,26 @@ account Expenses:The Bakery
                (list
                 "Expenses:The Bakery"))))))
 
+(ert-deftest ledger-complete/test-ledger-accounts-exclude-function ()
+  ;; TODO: Why doesn't this work in batch?
+  :tags '(interactive)
+  (with-temp-buffer
+    (insert "account Assets:Checking:Bank A
+    assert date<=[1990-01-01]
+account Assets:Checking:Bank B")
+    (let ((ledger-accounts-exclude-function
+           (lambda (i) "Exclude all entries with a subdirective."
+             (cdr i))))
+      (should (equal (ledger-accounts-list-in-buffer)
+                     (list "Assets:Checking:Bank B"))))
+    (let ((ledger-accounts-exclude-function (lambda (_) t)))
+      (should (equal (ledger-accounts-list-in-buffer)
+                     nil)))
+    (let ((ledger-accounts-exclude-function (lambda (_) nil)))
+      (should (equal (ledger-accounts-list-in-buffer)
+                     (list "Assets:Checking:Bank A"
+                           "Assets:Checking:Bank B"))))))
+
 (provide 'complete-test)
 
 ;;; complete-test.el ends here


### PR DESCRIPTION
New option ledger-accounts-exclude-function if non-nil is a function that can be used to filter accounts that ledger-mode offers for completion. It gets one argument which is a list containing the account name and any subdirectives associated with the account.

I made this because I have quite a few "closed" accounts that I don't want offered by completion:

```
account Assets:Old Checking
    assert date<=[2018-01-01]
```

There's also a new function ledger-accounts-in-buffer that returns a list of accounts along with any subdirectives.