### PR TITLE
Read directory-local variables in reports

### DIFF
--- a/ledger-report.el
+++ b/ledger-report.el
@@ -217,7 +217,8 @@ See documentation for the function `ledger-master-file'")
     ))
 
 (define-derived-mode ledger-report-mode special-mode "Ledger-Report"
-  "A mode for viewing ledger reports.")
+  "A mode for viewing ledger reports."
+  (hack-dir-local-variables-non-file-buffer))
 
 (defconst ledger-report--extra-args-marker "[[ledger-mode-flags]]")
 


### PR DESCRIPTION
This is useful when a directory has a definition for the
variable`ledger-reports`. I guess it can be useful for other variables
too so I when for a simple and generic solution.

* ledger-report.el (ledger-report-mode): Call
`hack-dir-local-variables-non-file-buffer` so that directory-local
variables are taken into account.