### PR TITLE
Enable navigation with C-M-a and C-M-e

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -41,3 +41,4 @@ how to use this.
 New commands ledger-navigate-next-uncleared and
 ledger-navigate-previous-uncleared move to the next and previous uncleared
 transactions. These don't have default keybindings.
+** C-M-a and C-M-e move to the next and previous transactions

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -264,6 +264,9 @@ With a prefix argument, remove the effective date."
 
     (define-key map [(meta ?p)] #'ledger-navigate-prev-xact-or-directive)
     (define-key map [(meta ?n)] #'ledger-navigate-next-xact-or-directive)
+    (define-key map [remap beginning-of-defun] #'ledger-navigate-prev-xact-or-directive)
+    (define-key map [remap end-of-defun] #'ledger-navigate-next-xact-or-directive)
+
     (define-key map [(meta ?q)] #'ledger-post-align-dwim)
     map)
   "Keymap for `ledger-mode'.")


### PR DESCRIPTION
* ledger-mode.el (ledger-mode-map): Remap beginning-of-defun and
end-of-defun to ledger-navigate-next-xact-or-directive and
ledger-navigate-prev-xact-or-directive respectively since there's
no real notion of a function in ledger-mode. This enables moving
between transactions with C-M-a and C-M-e.