### PR TITLE
Handle invisible transactions when navigating

### DIFF
--- a/test/navigate-test.el
+++ b/test/navigate-test.el
@@ -71,6 +71,31 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=441"
     (should (bobp))
     ))
 
+(ert-deftest ledger-navigate-invisible ()
+  :tags '(navigate)
+  (with-temp-buffer
+    (insert
+     "2011/01/27 Book Store
+    Expenses:Books                       $20.00
+    Liabilities:MasterCard
+
+2011/04/25 Tom's Used Cars
+    Expenses:Auto                    $ 5,500.00
+    Assets:Checking
+
+2011/04/27 Bookstore
+    Expenses:Books                       $20.00
+    Assets:Checking
+
+2011/12/01 * Sale
+    Assets:Checking                     $ 30.00
+    Income:Sales")
+    (ledger-mode)
+    (goto-char (point-min))
+    (ledger-occur "Books")
+    (ledger-navigate-next-xact-or-directive)
+    (should (looking-at-p (regexp-quote "2011/04/27 Bookstore")))))
+
 
 (provide 'navigate-test)
 


### PR DESCRIPTION
This allows next and prev navigate commands to work better with `ledger-occur`.

Adds an optional argument to `ledger-navigate-start-xact-or-directive-p` which indicates whether to consider invisible points when determining if point is at beginning of xact or directive.

This also refactors `ledger-navigate-prev-xact-or-directive` to use the same recursive logic as `ledger-navigate-next-xact-or-directive`.  I'm not sure if one or the other performs better but I think the recursive logic is easier to understand and it seems reasonable they should both use the same logic.

