### PR TITLE
Handle prefixed negation on commoditized amounts

### DIFF
--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -299,13 +299,22 @@
 (ledger-define-regexp commoditized-amount
   (macroexpand
    `(rx (group
-         (or (and (regexp ,ledger-commodity-no-group-regexp)
-                  (*? blank)
-                  (regexp ,ledger-amount-no-group-regexp))
-             (and (regexp ,ledger-amount-no-group-regexp)
-                  (*? blank)
-                  (regexp ,ledger-commodity-no-group-regexp))))))
-  "")
+         (or
+          ;; Match commodity before amount, with optional
+          ;; minus sign allowed before commodity.
+
+          ;; Ex: "$100" or "-$100"
+          (and (opt ?-)
+               (regexp ,ledger-commodity-no-group-regexp)
+               (*? blank)
+               (regexp ,ledger-amount-no-group-regexp))
+          ;; Match commodity after amount
+
+          ;; Ex: "100 Dollars"
+          (and (regexp ,ledger-amount-no-group-regexp)
+               (*? blank)
+               (regexp ,ledger-commodity-no-group-regexp))))))
+  "Regexp to match a commodity with amount such as \"$100\" or \"100 Dollars\"")
 
 (ledger-define-regexp commodity-annotations
   (macroexpand

--- a/test/context-test.el
+++ b/test/context-test.el
@@ -305,6 +305,22 @@ https://github.com/ledger/ledger-mode/issues/352"
      (should (equal "$100"
                     (ledger-context-field-value context 'cost))))))
 
+(ert-deftest ledger-context/test-011 ()
+  "Regress test for #211
+https://github.com/ledger/ledger-mode/issues/211"
+  :tags '(context regress)
+
+  (ledger-tests-with-temp-file
+   "2004/05/01 * Checking balance
+  Assets:Bank:Checking        -$1,000.00
+  Equity:Opening Balances
+"
+   (goto-char 65)                      ; on the amount 1,000.00
+   (let ((context (ledger-context-at-point)))
+     (should (eq (ledger-context-current-field context) 'commoditized-amount))
+     (should (equal "-$1,000.00"
+                    (ledger-context-field-value context 'commoditized-amount))))))
+
 (provide 'context-test)
 
 ;;; context-test.el ends here


### PR DESCRIPTION
This includes prefixed `-` characters when matching commoditized amounts.

Fixes #211