### PR TITLE
Use :extend in ledger-font-xact-highlight-face in Emacs>=27

### DIFF
--- a/ledger-fonts.el
+++ b/ledger-fonts.el
@@ -69,7 +69,9 @@
   :group 'ledger-faces)
 
 (defface ledger-font-xact-highlight-face
-  `((t :inherit ledger-occur-xact-face))
+  `((t
+     ,@(and (>= emacs-major-version 27) '(:extend t))
+     :inherit ledger-occur-xact-face))
   "Default face for transaction under point"
   :group 'ledger-faces)
 


### PR DESCRIPTION
This is a new face attribute in Emacs 27 and without this, the
highlighting stops at the end of the text instead of continuing to the
end of the window.