### PR TITLE
Mark report buffer not modified in ledger-report-redo

### DIFF
--- a/ledger-report.el
+++ b/ledger-report.el
@@ -576,6 +576,7 @@ arguments returned by `ledger-report--compute-extra-args'."
         (ledger-report-reverse-lines))
       (when ledger-report-auto-refresh-sticky-cursor
         (forward-line (- ledger-report-cursor-line-number 5)))
+      (set-buffer-modified-p nil)
       (run-hooks 'ledger-report-after-report-hook)
       (pop-to-buffer cur-buf))))
 


### PR DESCRIPTION
Fix #226.

An alternative would be to check at the beginning of `ledger-report` to see if the current buffer is a `ledger-report-mode` buffer and not prompt the user to save, but that seems less clean than this approach.