### PR TITLE
Use a calendar for reading dates

### DIFF
--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -174,8 +174,7 @@ MOMENT is an encoded date"
          (full-date-string (ledger-format-date reference-date))
          ;; Pre-fill year and month, but not day: this assumes DD is the last format arg.
          (initial-string (replace-regexp-in-string "[0-9]+$" "" full-date-string))
-         (entered-string (read-string "Transaction: "
-                                      initial-string 'ledger-minibuffer-history)))
+         (entered-string (ledger-read-date "Date: ")))
     (if (string= initial-string entered-string)
         full-date-string
       entered-string)))


### PR DESCRIPTION
* ledger-xact.el (ledger-read-transaction): Use ledger-read-date,
which uses org-read-date, which has a nice calendar. Now C-c C-a pops
up with a calendar and has movement with the usual org keybindings. As
a bonus, input like +2w now works too.


----

#