### PR TITLE
Set project(ledger-mode) to shut cmake up.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
+project(ledger-mode)
 
 set(EMACS_LISP_SOURCES
   ledger-check.el


### PR DESCRIPTION
Without this, cmake raises an objection:

> CMake Warning (dev) in CMakeLists.txt:
>   No project() command is present.  The top-level CMakeLists.txt file must
>   contain a literal, direct call to the project() command.  Add a line of
>   code such as
>
>     project(ProjectName)
>
>   near the top of the file, but after cmake_minimum_required().
>
>   CMake is pretending there is a "project(Project)" command on the first
>   line.
> This warning is for project developers.  Use -Wno-dev to suppress it.

```
% cmake --version
cmake version 3.16.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```