### PR TITLE
Stop at end of last line, not at first character of next line.

### DIFF
--- a/ledger-navigate.el
+++ b/ledger-navigate.el
@@ -116,7 +116,7 @@ Requires empty line separating xacts."
                       (point)))
         (end (progn (forward-line 1)
                     (ledger-navigate-skip-lines-forwards "[ \t]")
-                    (point)))
+                    (1- (point))))
         (comment-re " *;"))
     ;; handle block comments here
     (goto-char begin)


### PR DESCRIPTION
Candidate fix for first part of <https://github.com/ledger/ledger-mode/issues/71>.