### PR TITLE
Use a cache for account completion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        emacs_version: [24.3, 24.4, 24.5, 25.1, 25.2, 25.3, 26.1, 26.2, 26.3, snapshot]
+        emacs_version: [25.1, 25.2, 25.3, 26.1, 26.2, 26.3, snapshot]
         include:
           - emacs_version: snapshot
             ledger_version: snapshot

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,4 +1,5 @@
 * Development (v4.1)
+** Ledger-mode now requires Emacs 25 or later
 ** ledger-add-transaction now uses org-read-date
 This is more consistent with the behavior of =ledger-copy-transaction-at-point=
 and =ledger-insert-effective-date=. In order to disable the pop-up calendar, bind

--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -314,7 +314,7 @@ Looks in `ledger-accounts-file' if set, otherwise the current buffer."
       (let ((prefix (buffer-substring-no-properties start end)))
         (list start end
               (if (functionp collection)
-                  (completion-table-dynamic
+                  (completion-table-with-cache
                    (lambda (_)
                      (cl-remove-if (apply-partially 'string= prefix) (funcall collection))))
                 collection)

--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -23,6 +23,8 @@
 ;; Functions providing payee and account auto complete.
 
 (require 'cl-lib)
+(eval-when-compile
+  (require 'subr-x))
 
 ;; In-place completion support
 
@@ -128,12 +130,7 @@ Then one of the elements this function returns will be
                              (point))))
               data)
           (dolist (d (split-string lines "\n"))
-            (setq d
-                  ;; TODO: This is basically (string-trim d) but string-trim
-                  ;; doesn't exist in Emacs 24. Replace once we drop Emacs 24.
-                  (if (string-match "[[:space:]]+" d)
-                      (substring d (match-end 0))
-                    d))
+            (setq d (string-trim d))
             (unless (string= d "")
               (if (string-match " " d)
                   (push (cons (substring d 0 (match-beginning 0))

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -4,7 +4,7 @@
 
 ;; This file is not part of GNU Emacs.
 
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This is free software; you can redistribute it and/or modify it under
 ;; the terms of the GNU General Public License as published by the Free

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,7 @@ CHECKDOC_BATCH_EL := ../tools/checkdoc-batch.el
 all: compile test
 
 %.elc: %.el
-	$(EMACS_BATCH) --eval "(progn (setq byte-compile-error-on-warn (>= emacs-major-version 25)) (batch-byte-compile))" $<
+	$(EMACS_BATCH) --eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" $<
 
 .PHONY: test
 test: test-interactive test-batch

--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -243,6 +243,43 @@ account Assets:Checking:Bank B")
                      (list "Assets:Checking:Bank A"
                            "Assets:Checking:Bank B"))))))
 
+(ert-deftest ledger-complete/test-account-completion-in-steps ()
+  (let ((completion-cycle-threshold t)
+        (ledger-complete-in-steps t))
+    (ledger-tests-with-temp-file
+        "2020-01-01 Opening Balances
+    Assets:Bank:Balance                       100.00 EUR
+    Equity:Opening Balances
+
+2020-02-01 Acme Widgetry GmbH
+    Assets:Bank:Deposit:20200201              200.00 EUR
+    Income:Salary
+
+2020-03-01 Gear
+    Assets:Reimbursements                      50.00 EUR
+    Assets:Bank:Balance
+
+2020-04-01 Fnord
+    As"
+      (goto-char (point-max))
+      (call-interactively 'completion-at-point)
+      (should
+       (equal (buffer-substring-no-properties (point-min) (point-max))
+              "2020-01-01 Opening Balances
+    Assets:Bank:Balance                       100.00 EUR
+    Equity:Opening Balances
+
+2020-02-01 Acme Widgetry GmbH
+    Assets:Bank:Deposit:20200201              200.00 EUR
+    Income:Salary
+
+2020-03-01 Gear
+    Assets:Reimbursements                      50.00 EUR
+    Assets:Bank:Balance
+
+2020-04-01 Fnord
+    Assets:")))))
+
 (provide 'complete-test)
 
 ;;; complete-test.el ends here

--- a/test/fontify-test.el
+++ b/test/fontify-test.el
@@ -617,7 +617,7 @@ https://groups.google.com/d/msg/ledger-cli/9zyWZW_fJmk/G56uVsqv0FAJ"
           (progn
             (setq ledger-fontify-xact-state-overrides t)
             (insert str)
-            (ledger-test-font-lock-fontify-buffer)
+            (font-lock-ensure)
             (should (equal (ledger-test-face-groups (buffer-string))
                            face-groups)))
         (setq ledger-fontify-xact-state-overrides nil)))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -152,18 +152,12 @@ The two arguments START and END are character positions."
 ;; Font lock test helpers
 ;; --------------------------------------------------------------------
 
-(defalias 'ledger-test-font-lock-fontify-buffer
-  (if (fboundp 'font-lock-ensure)
-      'font-lock-ensure                 ; Emacs >= 25
-    'font-lock-fontify-buffer))         ; Emacs <= 24
-
-
 (defun ledger-test-fontify-string (str)
   "Fontify `STR' in ledger mode."
   (with-temp-buffer
     (ledger-mode)
     (insert str)
-    (ledger-test-font-lock-fontify-buffer)
+    (font-lock-ensure)
     (buffer-string)))
 
 


### PR DESCRIPTION
Fix for #237. 

Requires `completion-table-with-cache` which requires Emacs 24.4 (we currently support back to 24.3). I took the opportunity to bump our minimum version up to 25. 25 was released ~4 years ago and AFAIK all the major distros have updated to at least 25.