### PR TITLE
Use input-date-format in ledger-format-date

### DIFF
--- a/ledger-init.el
+++ b/ledger-init.el
@@ -52,7 +52,7 @@ ISO 8601 dates."
   "Format DATE according to the current preferred date format.
 Returns the current date if DATE is nil or not supplied."
   (format-time-string
-   (or (cdr (assoc "date-format" ledger-environment-alist))
+   (or (cdr (assoc "input-date-format" ledger-environment-alist))
        ledger-default-date-format)
    date))
 


### PR DESCRIPTION
input-date-format is the format used for the ledger, date-format is
the format used for reports. ledger-format-date is used for e.g.
ledger-add-transaction so it should use input-date-format.

Closes #245