### PR TITLE
Transaction folding

### DIFF
--- a/ledger-occur.el
+++ b/ledger-occur.el
@@ -202,13 +202,11 @@ temporarily opened when doing incremental search."
         (when (and (> (- e b) 1)            ; not an empty line
                    (<= p e) (>= p b)        ; point is within the boundaries
                    (not (region-active-p))) ; no active region
-          (goto-char b)
           (save-excursion
+            (goto-char b)
             (goto-char (line-end-position))
             (if (hs-overlay-at (point))  ;; if transaction is hidden show it
-                (progn
-                  (save-excursion (hs-show-block))
-                  (goto-char b))
+                (hs-show-block)
               (goto-char b)
               (hs-discard-overlays (line-end-position) e)
               (hs-make-overlay (line-end-position) e 'code)

--- a/ledger-occur.el
+++ b/ledger-occur.el
@@ -193,7 +193,7 @@ A transaction block is identified as in ledger-highlight-xact-under-point.
 Overlay of type `code' is used so that hidden blocks are
 temporarily opened when doing incremental search."
   (interactive)
-  (if (not (and (boundp 'hs-minor-mode) hs-minor-mode))
+  (if (not (bound-and-true-p hs-minor-mode))
       (message "Enable hs-minor-mode to use this functionality.")
     (let ((exts (ledger-navigate-find-element-extents (point))))
       (let ((b (car exts))

--- a/test/occur-test.el
+++ b/test/occur-test.el
@@ -181,6 +181,50 @@ https://github.com/ledger/ledger-mode/issues/415"
   Income:Salary
 "))))
 
+(ert-deftest ledger-occur/test-005 ()
+  "Test transaction folding"
+  :tags '(transaction folding)
+
+  (ledger-tests-with-temp-file
+   "2011/01/02 Grocery Store
+  Expenses:Food:Groceries             $ 65.00
+  * Assets:Checking
+
+2011/01/05 Employer
+  * Assets:Checking                 $ 2000.00
+  Income:Salary
+"
+   (progn
+     (hs-minor-mode t)
+     (ledger-mode-folding-toggle-transactions))
+   (should
+    (equal (ledger-test-visible-buffer-string)
+           "2011/01/02 Grocery Store
+
+2011/01/05 Employer
+"))))
+
+(ert-deftest ledger-occur/test-006 ()
+  "Test transaction folding together with ledger-occur-mode"
+  :tags '(transaction folding)
+
+  (ledger-tests-with-temp-file
+   "2011/01/02 Grocery Store
+  Expenses:Food:Groceries             $ 65.00
+  * Assets:Checking
+
+2011/01/05 Employer
+  * Assets:Checking                 $ 2000.00
+  Income:Salary
+"
+   (progn
+     (hs-minor-mode t)
+     (ledger-occur "Groceries")
+     (ledger-mode-folding-toggle-transactions))
+   (should
+    (equal (ledger-test-visible-buffer-string)
+           "2011/01/02 Grocery Store
+"))))
 
 (provide 'occur-test)
 


### PR DESCRIPTION
Even though `ledger-occur` can be used to narrow down a buffer based on a regex, I find it useful to have, in addiction, folding of transaction records. This PR implements the latter. For example, folding a transaction
```
2011/01/02 Grocery Store
    Expenses:Food:Groceries                  $ 65.00
    * Assets:Checking
```
results in
```
2011/01/02 Grocery Store...
```
Two `interactive` functions are exposed:
- `ledger-mode-transaction-toggle-folding`: hide/show transaction under point 
- `ledger-mode-folding-toggle-transactions`: hide/show all transactions in the buffer

`ledger-occur` and transaction folding can be used to complement each other.

The buffer-local variable `ledger-mode-toggle-invisible-transactions` can be used to enable/disable folding of invisible transactions (i.e., transactions whose overlay has been set using `ledger-occur`).

Transaction blocks are detected using the same approach as in `ledger-highlight-xact-under-point` (probably some code refactoring should be done).

The transaction folding functionality has been added to the `ledger-occur.el` file even though probably a new file should be used (my aim was to do the least amount modifications). The same thing applies to the unit tests. 

The function `ledger-occur-make-invisible-overlay` has been modified by adding `(overlay-put ovl 'display "")` in order to avoid undesired trailing ellipsis when using `ledger-occur` together with transaction folding. 

Overlay of type `'code` has been used in order for incremental search to temporarily open folded blocks. 