### PR TITLE
Recognize Windows-style absolute paths in links

### DIFF
--- a/ledger-report.el
+++ b/ledger-report.el
@@ -487,7 +487,7 @@ Optionally EDIT the command."
 
 (defun ledger-report--add-links ()
   "Replace file and line annotations with buttons."
-  (while (re-search-forward "^\\(/[^:]+\\)?:\\([0-9]+\\)?:" nil t)
+  (while (re-search-forward "^\\(\\(?:/\\|[a-zA-Z]:[\\/]\\)[^:]+\\)?:\\([0-9]+\\)?:" nil t)
     (let ((file (match-string 1))
           (line (string-to-number (match-string 2))))
       (delete-region (match-beginning 0) (match-end 0))


### PR DESCRIPTION
Fix #275.  Update the regular expression for absolute paths in the ledger report to allow Windows-style absolute paths (`C:\...`) in addition to Unix-style ones (`/...`).