### PR TITLE
ledger-add-transaction follows ledger-default-date-format

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -3,7 +3,9 @@
 ** ledger-add-transaction now uses org-read-date
 This is more consistent with the behavior of =ledger-copy-transaction-at-point=
 and =ledger-insert-effective-date=. In order to disable the pop-up calendar, bind
-=org-read-date-popup-calendar= to nil.
+=org-read-date-popup-calendar= to nil. The command now prompts twice - once for
+the date and another time for the xact text. If you find this annoying, set
+=ledger-add-transaction-prompt-for-text= to nil.
 * Release v4.0.0
 ** The completion system now respects whatever completion system the user prefers
 Some users prefer different completion systems such as ivy or helm. To get the

--- a/doc/ledger-mode.texi
+++ b/doc/ledger-mode.texi
@@ -173,8 +173,7 @@ Additionally you can use the ledger @command{xact} command, by either typing
 @kbd{C-c C-a} or using @samp{Add Transaction} menu entry. Then typing a close
 match to the payee. Ledger-mode will call @command{ledger xact} with the data
 you enter and place the transaction in the proper chronological place in the
-ledger. Subsequent calls to @kbd{C-c C-a} remember the last date so entering
-many dates in the past is easy. The date format can be changed by modifying
+ledger. The date format can be changed by modifying
 @option{ledger-default-date-format}.
 
 @node Reconciliation, Reports, Quick Add, Quick Demo

--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -40,6 +40,13 @@
   :type 'boolean
   :group 'ledger)
 
+(defcustom ledger-add-transaction-prompt-for-text t
+  "When non-nil, use ledger xact to format transaction.
+When nil, `ledger-add-transaction' will not prompt twice."
+  :type 'boolean
+  :package-version '(ledger-mode . "4.0.1")
+  :group 'ledger)
+
 (defvar-local ledger-xact-highlight-overlay (list))
 
 (defun ledger-highlight-make-overlay ()
@@ -172,14 +179,10 @@ MOMENT is an encoded date"
 
 (defun ledger-read-transaction ()
   "Read the text of a transaction, which is at least the current date."
-  (let* ((reference-date (or ledger-add-transaction-last-date (current-time)))
-         (full-date-string (ledger-format-date reference-date))
-         ;; Pre-fill year and month, but not day: this assumes DD is the last format arg.
-         (initial-string (replace-regexp-in-string "[0-9]+$" "" full-date-string))
-         (entered-string (ledger-read-date "Date: ")))
-    (if (string= initial-string entered-string)
-        full-date-string
-      entered-string)))
+  (let ((date (ledger-read-date "Date: ")))
+    (concat date " "
+            (when ledger-add-transaction-prompt-for-text
+              (read-string (concat "xact " date ": ") nil 'ledger-minibuffer-history)))))
 
 (defun ledger-parse-iso-date (date)
   "Try to parse DATE using `ledger-iso-date-regexp' and return a time value or nil."

--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -218,7 +218,7 @@ date is requested via `ledger-read-date'."
           (insert
            (with-temp-buffer
              (apply #'ledger-exec-ledger ledger-buf (current-buffer) "xact"
-                    (mapcar 'eval args))
+                    (append (mapcar 'eval args) '("-y") (list ledger-default-date-format)))
              (goto-char (point-min))
              (ledger-post-align-postings (point-min) (point-max))
              (buffer-string))


### PR DESCRIPTION
## Problem:

`ledger-add-transaction` does not respect the value of `ledger-default-date-format` so for my ledger, it inserts dates as "2021/03/16" when I use "2021-03-16"

## Solution:

The command line argument `-y` passed to ledger with the value of that variable.  Viz. <https://www.ledger-cli.org/3.0/doc/ledger3.html#Output-customization>

Respectfully submitted,