### PR TITLE
Fix #295

### DIFF
--- a/ledger-commodities.el
+++ b/ledger-commodities.el
@@ -119,7 +119,7 @@ See `ledger-environment-alist' for DECIMAL-COMMA."
                       (assoc "decimal-comma" ledger-environment-alist))
                   (ledger-strip str "[.]")
                 (ledger-strip str ","))))
-    (while (string-match "," nstr)  ;if there is a comma now, it is a thousands separator
+    (while (string-match "," nstr)  ;if there is a comma now, it is a decimal point
       (setq nstr (replace-match "." nil nil nstr)))
     (string-to-number nstr)))
 

--- a/ledger-post.el
+++ b/ledger-post.el
@@ -168,7 +168,9 @@ regular text."
             (delete-region (match-beginning 0) (match-end 0))
             (push-mark)
             (calc)
-            (calc-eval val-string 'push)) ;; edit the amount
+            ;; edit the amount, first removing thousands separators and
+            ;; converting decimal commas to calc's input format
+            (calc-eval (number-to-string (ledger-string-to-number val-string)) 'push))
         (progn ;;make sure there are two spaces after the account name and go to calc
           (if (search-backward "  " (- (point) 3) t)
               (goto-char (line-end-position))


### PR DESCRIPTION
Fix #295 by removing thousands separators and converting decimal commas from the amount string before passing it to `calc-eval`.