### PR TITLE
add ledger-default-date-format to ledger-add-transaction

### DIFF
--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -218,7 +218,8 @@ date is requested via `ledger-read-date'."
           (insert
            (with-temp-buffer
              (apply #'ledger-exec-ledger ledger-buf (current-buffer) "xact"
-                    (mapcar 'eval args))
+                    (append (mapcar 'eval args) '("-y")
+                            (list ledger-default-date-format)))
              (goto-char (point-min))
              (ledger-post-align-postings (point-min) (point-max))
              (buffer-string))


### PR DESCRIPTION
ledger-add-transaction disregarded the ledger-default-date-format, but this provides it on the command line as an argument

Respectfully submitted