### PR TITLE
Define ledger-iso-date-format before ledger-default-date-format

### DIFF
--- a/ledger-init.el
+++ b/ledger-init.el
@@ -37,6 +37,9 @@
 Adding the dotted pair (\"decimal-comma\" . t) will tell ledger
 to treat commas as decimal separator.")
 
+(defconst ledger-iso-date-format "%Y-%m-%d"
+  "The format for ISO 8601 dates.")
+
 (defcustom ledger-default-date-format "%Y/%m/%d"
   "The date format that ledger uses throughout.
 Set this to the value of `ledger-iso-date-format' if you prefer
@@ -44,9 +47,6 @@ ISO 8601 dates."
   :type 'string
   :package-version '(ledger-mode . "4.0.0")
   :group 'ledger)
-
-(defconst ledger-iso-date-format "%Y-%m-%d"
-  "The format for ISO 8601 dates.")
 
 (defun ledger-format-date (&optional date)
   "Format DATE according to the current preferred date format.


### PR DESCRIPTION
This fixes the following customization:

    (custom-set-variables
     '(ledger-default-date-format ledger-iso-date-format))

Otherwise, when `ledger-init` is loaded, Custom attempts to evaluate
`ledger-iso-date-format` immediately after `ledger-default-date-format` is
defined but before `ledger-iso-date-format` is defined, which leads to an
unbound variable error.