### PR TITLE
Fix payee including trailing newline

### DIFF
--- a/ledger-context.el
+++ b/ledger-context.el
@@ -37,11 +37,11 @@
 (defconst ledger-amount-string ledger-amount-regexp)
 (defconst ledger-commoditized-amount-string ledger-commoditized-amount-regexp)
 (defconst ledger-balance-assertion-string ledger-balance-assertion-regexp)
-(defconst ledger-comment-string "[ \t]*;[ \t]*\\(.*?\\)")
+(defconst ledger-comment-string "\\(?:[ \t]*\n\\)?[ \t]*;[ \t]*\\(.*?\\)")
 (defconst ledger-nil-string "\\([ \t]+\\)")
 (defconst ledger-date-string "^\\([0-9]\\{4\\}[/-][01]?[0-9][/-][0123]?[0-9]\\)\\(?:=[0-9]\\{4\\}[/-][01]?[0-9][/-][0123]?[0-9]\\)?")
 (defconst ledger-code-string "\\((.*)\\)?")
-(defconst ledger-payee-string "\\(.*[^[:space:]]\\)")
+(defconst ledger-payee-string "\\(.*[^[:space:]\n]\\)")
 
 
 (defun ledger-get-regex-str (name)

--- a/test/context-test.el
+++ b/test/context-test.el
@@ -268,6 +268,23 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=257"
      (should (equal "$1,000.00"
                     (ledger-context-field-value context 'commoditized-amount))))))
 
+(ert-deftest ledger-context/test-009 ()
+  "Regress test for #302.
+https://github.com/ledger/ledger-mode/issues/302"
+  :tags '(context regress)
+
+  (ledger-tests-with-temp-file
+   "2016/08/12 KFC
+ ; xact note
+ a  $7
+ b"
+   (goto-char 12)                       ; on the payee
+   (let ((context (ledger-context-at-point)))
+     (should (eq (ledger-context-current-field context) 'payee))
+     (should (equal "KFC"
+                    (ledger-context-field-value context 'payee)))
+     (should (equal "xact note"
+                    (ledger-context-field-value context 'comment))))))
 
 (provide 'context-test)
 


### PR DESCRIPTION
Fix #302 by "moving" the newline from the payee regex to the comment regex.