### PR TITLE
ledger-init: Fix type error in ledger-init-load-init-file

### DIFF
--- a/ledger-init.el
+++ b/ledger-init.el
@@ -81,17 +81,17 @@ Returns the current date if DATE is nil or not supplied."
 (defun ledger-init-load-init-file ()
   "Load and parse the .ledgerrc file."
   (interactive)
-  (let ((init-base-name (file-name-nondirectory ledger-init-file-name)))
-    (if (get-buffer init-base-name) ;; init file already loaded, parse it and leave it
-        (setq ledger-environment-alist
-              (ledger-init-parse-initialization init-base-name))
-      (when (and ledger-init-file-name
-                 (file-exists-p ledger-init-file-name)
-                 (file-readable-p ledger-init-file-name))
-        (let ((init-buffer (find-file-noselect ledger-init-file-name)))
+  (when ledger-init-file-name
+    (let ((init-base-name (file-name-nondirectory ledger-init-file-name)))
+      (if (get-buffer init-base-name) ;; init file already loaded, parse it and leave it
           (setq ledger-environment-alist
-                (ledger-init-parse-initialization init-buffer))
-          (kill-buffer init-buffer))))))
+                (ledger-init-parse-initialization init-base-name))
+        (when (and (file-exists-p ledger-init-file-name)
+                   (file-readable-p ledger-init-file-name))
+          (let ((init-buffer (find-file-noselect ledger-init-file-name)))
+            (setq ledger-environment-alist
+                  (ledger-init-parse-initialization init-buffer))
+            (kill-buffer init-buffer)))))))
 
 (provide 'ledger-init)
 


### PR DESCRIPTION
When ledger-init-file-name is set to nil, this function fails with a type error
in `file-name-nondirectory`.

This PR changes load-init-file to only attempt any sort of loading if `ledger-init-file-name` is non-nil.