### PR TITLE
ledger-exec: Pass in ledger-default-date-format

### DIFF
--- a/ledger-exec.el
+++ b/ledger-exec.el
@@ -89,6 +89,7 @@ otherwise the error output is displayed and an error is raised."
                    (apply #'call-process-region
                           (append (list (point-min) (point-max)
                                         ledger-binary-path nil (list outbuf errfile) nil "-f" "-")
+                                  (list "--date-format" ledger-default-date-format)
                                   args)))))
             (if (ledger-exec-success-p exit-code outbuf)
                 outbuf


### PR DESCRIPTION
This fixes the xact-test test suite for me, which was broken because my
~/.ledgerrc specifies the ISO date format, whereas the test expects the default
`%Y/%m/%d` format.

I think this is one place where "use ledger-default-date-format consistently when inserting new transactions" was violated.