### PR TITLE
Do not load user's ledger init file in tests

### DIFF
--- a/test/fontify-test.el
+++ b/test/fontify-test.el
@@ -612,15 +612,16 @@ https://groups.google.com/d/msg/ledger-cli/9zyWZW_fJmk/G56uVsqv0FAJ"
            "Equity:Opening Balances"  ledger-font-posting-account-face)))
 
     (with-temp-buffer
-      (ledger-mode)
-      (unwind-protect
-          (progn
-            (setq ledger-fontify-xact-state-overrides t)
-            (insert str)
-            (font-lock-ensure)
-            (should (equal (ledger-test-face-groups (buffer-string))
-                           face-groups)))
-        (setq ledger-fontify-xact-state-overrides nil)))))
+      (let (ledger-init-file-name)
+        (ledger-mode)
+        (unwind-protect
+            (progn
+              (setq ledger-fontify-xact-state-overrides t)
+              (insert str)
+              (font-lock-ensure)
+              (should (equal (ledger-test-face-groups (buffer-string))
+                             face-groups)))
+          (setq ledger-fontify-xact-state-overrides nil))))))
 
 ;; --------------------------------------------------------------------------------------------------------
 
@@ -2618,11 +2619,12 @@ payeee Charity
             "Expenses:Food"  ledger-font-posting-account-face
             "7 EUR"          ledger-font-posting-amount-face)))
     (with-temp-buffer
-      (ledger-mode)
-      (insert pre-str str post-str)
-      (font-lock-fontify-region beg end nil)
-      (should (equal (ledger-test-face-groups (buffer-substring beg end))
-                     face-groups)))))
+      (let (ledger-init-file-name)
+        (ledger-mode)
+        (insert pre-str str post-str)
+        (font-lock-fontify-region beg end nil)
+        (should (equal (ledger-test-face-groups (buffer-substring beg end))
+                       face-groups))))))
 
 
 (ert-deftest ledger-fontify/test-100 ()

--- a/test/navigate-test.el
+++ b/test/navigate-test.el
@@ -45,9 +45,8 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=441"
 
 (ert-deftest ledger-navigate-uncleared ()
   :tags '(navigate)
-  (with-temp-buffer
-    (insert
-     "2011/01/27 Book Store
+  (ledger-tests-with-temp-file
+   "2011/01/27 Book Store
     Expenses:Books                       $20.00
     Liabilities:MasterCard
 
@@ -61,15 +60,12 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=441"
 
 2011/12/01 * Sale
     Assets:Checking                     $ 30.00
-    Income:Sales")
-    (ledger-mode)
-    (goto-char (point-min))
-    (ledger-navigate-next-uncleared)
-    (should (looking-at-p (regexp-quote "2011/04/27 Bookstore")))
-    (should-error (ledger-navigate-next-uncleared))
-    (ledger-navigate-previous-uncleared)
-    (should (bobp))
-    ))
+    Income:Sales"
+   (ledger-navigate-next-uncleared)
+   (should (looking-at-p (regexp-quote "2011/04/27 Bookstore")))
+   (should-error (ledger-navigate-next-uncleared))
+   (ledger-navigate-previous-uncleared)
+   (should (bobp))))
 
 
 (provide 'navigate-test)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -118,7 +118,8 @@ BODY is code to be executed within the temp buffer.  Point is
 always located at the beginning of buffer."
   (declare (indent 1) (debug t))
   `(let* ((temp-file (make-temp-file "ledger-tests-"))
-          (ledger-buffer (find-file-noselect temp-file)))
+          (ledger-buffer (find-file-noselect temp-file))
+          (ledger-init-file-name nil))
      (unwind-protect
          (with-current-buffer ledger-buffer
            (switch-to-buffer ledger-buffer)    ; this selects window
@@ -154,11 +155,12 @@ The two arguments START and END are character positions."
 
 (defun ledger-test-fontify-string (str)
   "Fontify `STR' in ledger mode."
-  (with-temp-buffer
-    (ledger-mode)
-    (insert str)
-    (font-lock-ensure)
-    (buffer-string)))
+  (let (ledger-init-file-name)
+    (with-temp-buffer
+      (ledger-mode)
+      (insert str)
+      (font-lock-ensure)
+      (buffer-string))))
 
 
 (defun ledger-test-face-groups (fontified)


### PR DESCRIPTION
This prevents individual user settings from affecting test results.

This PR depends on #304 and otherwise doesn't pass tests.