### PR TITLE
Fix #307: ledger-add-transaction inserts in the wrong place when xacts have effective dates 

### DIFF
--- a/ledger-exec.el
+++ b/ledger-exec.el
@@ -89,6 +89,7 @@ otherwise the error output is displayed and an error is raised."
                    (apply #'call-process-region
                           (append (list (point-min) (point-max)
                                         ledger-binary-path nil (list outbuf errfile) nil "-f" "-")
+                                  (list "--date-format" ledger-default-date-format)
                                   args)))))
             (if (ledger-exec-success-p exit-code outbuf)
                 outbuf

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -28,7 +28,7 @@
 (require 'rx)
 (require 'cl-lib)
 
-(defvar ledger-iso-date-regex)
+(defvar ledger-iso-date-regexp)
 
 (defconst ledger-amount-decimal-comma-regex
   "-?[1-9][0-9.]*[,]?[0-9]*")
@@ -184,7 +184,7 @@
 (put 'ledger-define-regexp 'lisp-indent-function 1)
 
 (ledger-define-regexp iso-date
-                      ( let ((sep '(or ?-  ?/)))
+                      (let ((sep '(or ?- ?/)))
                         (rx (group
                              (and (group (= 4 num))
                                   (eval sep)

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -358,13 +358,31 @@
           "\\([ \t]*[@={]@?[^\n;]+?\\)?"
           "\\([ \t]+;.+?\\|[ \t]*\\)?$"))
 
-(defconst ledger-iterate-regex
-  (concat "\\(\\(?:Y\\|year\\)\\s-+\\([0-9]+\\)\\|"  ;; Catches a Y/year directive
-          ledger-iso-date-regexp
-          "\\([ *!]+\\)"  ;; mark
-          "\\((.*)\\)?"  ;; code
-          "\\([[:word:] ]+\\)"   ;; desc
-          "\\)"))
+(ledger-define-regexp year
+  (macroexpand `(rx (group (+ (any "0-9")))))
+  "")
+
+(ledger-define-regexp payee
+  (macroexpand `(rx (group (+? nonl))))
+  "")
+
+(ledger-define-regexp iterate
+  (macroexpand `(rx  (or (and (or "Y" "year")
+                              (+ (syntax ?-))
+                              (regexp ,ledger-year-regexp))
+                         (and (regexp ,ledger-iso-date-regexp)
+                              (? (and (+ blank) (regexp ,ledger-state-regexp)))
+                              (? (and (+ blank) (regexp ,ledger-code-regexp)))
+                              (+ blank)
+                              (regexp ,ledger-payee-regexp)
+                              (? (regexp ,ledger-end-note-regexp))))))
+  ""
+  year
+  iso-date
+  state
+  code
+  payee
+  (note end-note))
 
 (defconst ledger-incomplete-date-regexp
   "\\(?:\\([0-9]\\{1,2\\}\\)[-/]\\)?\\([0-9]\\{1,2\\}\\)")

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -124,8 +124,14 @@
                                    "-group"))
                   string))))))
 
-      (dolist (arg args)
-        (let (var grouping target)
+      (while args
+        (let (arg var grouping target force-increment)
+          (setq arg (pop args))
+
+          (when (eq arg :separate)
+            (setq arg (pop args))
+            (setq force-increment t))
+
           (if (symbolp arg)
               (setq var arg target arg)
             (cl-assert (listp arg))
@@ -137,7 +143,8 @@
                     target (cl-caddr arg))))
 
           (if (and last-group
-                   (not (eq last-group (or grouping target))))
+                   (or (not (eq last-group (or grouping target)))
+                       force-increment))
               (cl-incf addend
                        (symbol-value
                         (intern-soft (concat "ledger-regex-"
@@ -193,6 +200,7 @@
                                  (? (and ?= (regexp ,ledger-iso-date-regexp))))))
                       "Match a compound date, of the form ACTUAL=EFFECTIVE"
                       (actual iso-date)
+                      :separate
                       (effective iso-date))
 
 (ledger-define-regexp state

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -305,7 +305,9 @@
                                (or (and ?\{ (regexp ,ledger-commoditized-amount-regexp) ?\})
                                    (and ?\[ (regexp ,ledger-iso-date-regexp) ?\])
                                    (and ?\( (not (any ?\))) ?\))))))
-                      "")
+                      ""
+                      commoditized-amount
+                      iso-date)
 
 (ledger-define-regexp cost
                       (macroexpand

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -246,22 +246,6 @@
                       code
                       (note end-note))
 
-(ledger-define-regexp recurring-line
-                      (macroexpand
-                       `(rx (and line-start
-                                 (regexp "\\[.+/.+/.+\\]")
-                                 (? (and (+ blank) (regexp ,ledger-state-regexp)))
-                                 (? (and (+ blank) (regexp ,ledger-code-regexp)))
-                                 (+ blank) (+? nonl)
-                                 (? (regexp ,ledger-end-note-regexp))
-                                 line-end)))
-                      "Match a transaction's first line (and optional notes)."
-                      (actual-date full-date actual)
-                      (effective-date full-date effective)
-                      state
-                      code
-                      (note end-note))
-
 (ledger-define-regexp account
                       (rx (group (and (not (any blank ?\[ ?\( ?: ?\;)) (*? nonl))))
                       "")

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -370,7 +370,7 @@
   (macroexpand `(rx  (or (and (or "Y" "year")
                               (+ (syntax ?-))
                               (regexp ,ledger-year-regexp))
-                         (and (regexp ,ledger-iso-date-regexp)
+                         (and (regexp ,ledger-full-date-regexp)
                               (? (and (+ blank) (regexp ,ledger-state-regexp)))
                               (? (and (+ blank) (regexp ,ledger-code-regexp)))
                               (+ blank)
@@ -378,7 +378,8 @@
                               (? (regexp ,ledger-end-note-regexp))))))
   ""
   year
-  iso-date
+  (actual-date full-date actual)
+  (effective-date full-date effective)
   state
   code
   payee

--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -124,22 +124,22 @@ MOMENT is an encoded date"
   (let* ((now (current-time))
          (current-year (nth 5 (decode-time now))))
     (while (not (eobp))
-      (when (looking-at ledger-iterate-regex)
-        (let ((found-y-p (match-string 2)))
+      (when (looking-at ledger-iterate-regexp)
+        (let ((found-y-p (match-string 1)))
           (if found-y-p
               (setq current-year (string-to-number found-y-p)) ;; a Y directive was found
             (let ((start (match-beginning 0))
-                  (year (match-string 4))
-                  (month (string-to-number (match-string 5)))
-                  (day (string-to-number (match-string 6)))
-                  (mark (match-string 7))
-                  (desc (match-string 9)))
+                  (year (match-string (+ ledger-regex-iterate-group-iso-date 1)))
+                  (month (string-to-number (match-string (+ ledger-regex-iterate-group-iso-date 2))))
+                  (day (string-to-number (match-string (+ ledger-regex-iterate-group-iso-date 3))))
+                  (state (match-string ledger-regex-iterate-group-state))
+                  (payee (match-string ledger-regex-iterate-group-payee)))
               (if (and year (> (length year) 0))
                   (setq year (string-to-number year)))
               (funcall callback start
                        (encode-time 0 0 0 day month
                                     (or year current-year))
-                       mark desc)))))
+                       state payee)))))
       (forward-line))))
 
 (defcustom ledger-copy-transaction-insert-blank-line-after nil

--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -129,9 +129,9 @@ MOMENT is an encoded date"
           (if found-y-p
               (setq current-year (string-to-number found-y-p)) ;; a Y directive was found
             (let ((start (match-beginning 0))
-                  (year (match-string (+ ledger-regex-iterate-group-iso-date 1)))
-                  (month (string-to-number (match-string (+ ledger-regex-iterate-group-iso-date 2))))
-                  (day (string-to-number (match-string (+ ledger-regex-iterate-group-iso-date 3))))
+                  (year (match-string (+ ledger-regex-iterate-group-actual-date 1)))
+                  (month (string-to-number (match-string (+ ledger-regex-iterate-group-actual-date 2))))
+                  (day (string-to-number (match-string (+ ledger-regex-iterate-group-actual-date 3))))
                   (state (match-string ledger-regex-iterate-group-state))
                   (payee (match-string ledger-regex-iterate-group-payee)))
               (if (and year (> (length year) 0))

--- a/test/regex-test.el
+++ b/test/regex-test.el
@@ -61,11 +61,14 @@
     "full-date"
     "full-note"
     "iso-date"
+    "iterate"
     "long-space"
     "note"
+    "payee"
     "post-line"
     "state"
-    "xact-line")
+    "xact-line"
+    "year")
   "Names of the regexps defined via `ledger-define-regexp'.")
 
 (defconst regex-test--ledger-define-regexp-defined-symbols-by-name
@@ -225,7 +228,7 @@ In particular, the group count and index variables should match EXPECTED."
 (ert-deftest ledger-regex/test-iterate ()
   (regex-test--test-regexp
    "iterate"
-   '((ledger-regex-iterate-group--count 10)
+   '((ledger-regex-iterate-group--count 9)
      (ledger-regex-iterate-group-code 7)
      (ledger-regex-iterate-group-iso-date 2)
      (ledger-regex-iterate-group-note 9)

--- a/test/regex-test.el
+++ b/test/regex-test.el
@@ -115,7 +115,9 @@ added to this file similar to the tests for the other regexps."
   "Check that the variables associated with the regex named NAME.
 
 In particular, the group count and index variables should match EXPECTED."
-  (should (equal (regex-test--dump-regex name) expected)))
+  (should (equal (regex-test--dump-regex name) expected))
+  (should (= (regexp-opt-depth (symbol-value (intern (concat "ledger-" name "-regexp"))))
+             (symbol-value (intern (concat "ledger-regex-" name "-group--count"))))))
 
 (ert-deftest ledger-regex/test-account ()
   (regex-test--test-regexp

--- a/test/regex-test.el
+++ b/test/regex-test.el
@@ -206,7 +206,7 @@ In particular, the group count and index variables should match EXPECTED."
    "full-date"
    '((ledger-regex-full-date-group--count 8)
      (ledger-regex-full-date-group-actual 1)
-     (ledger-regex-full-date-group-effective 1))))
+     (ledger-regex-full-date-group-effective 5))))
 
 (ert-deftest ledger-regex/test-full-note ()
   (regex-test--test-regexp
@@ -253,7 +253,7 @@ In particular, the group count and index variables should match EXPECTED."
    '((ledger-regex-xact-line-group--count 11)
      (ledger-regex-xact-line-group-actual-date 1)
      (ledger-regex-xact-line-group-code 10)
-     (ledger-regex-xact-line-group-effective-date 1)
+     (ledger-regex-xact-line-group-effective-date 5)
      (ledger-regex-xact-line-group-note 11)
      (ledger-regex-xact-line-group-state 9))))
 

--- a/test/regex-test.el
+++ b/test/regex-test.el
@@ -168,8 +168,9 @@ In particular, the group count and index variables should match EXPECTED."
 (ert-deftest ledger-regex/test-commodity-annotations ()
   (regex-test--test-regexp
    "commodity-annotations"
-   '((ledger-regex-commodity-annotations-group 1)
-     (ledger-regex-commodity-annotations-group--count 1))))
+   '((ledger-regex-commodity-annotations-group--count 5)
+     (ledger-regex-commodity-annotations-group-commoditized-amount 1)
+     (ledger-regex-commodity-annotations-group-iso-date 2))))
 
 (ert-deftest ledger-regex/test-commodity-no-group ()
   (regex-test--test-regexp

--- a/test/regex-test.el
+++ b/test/regex-test.el
@@ -222,6 +222,17 @@ In particular, the group count and index variables should match EXPECTED."
    '((ledger-regex-iso-date-group 1)
      (ledger-regex-iso-date-group--count 4))))
 
+(ert-deftest ledger-regex/test-iterate ()
+  (regex-test--test-regexp
+   "iterate"
+   '((ledger-regex-iterate-group--count 10)
+     (ledger-regex-iterate-group-code 7)
+     (ledger-regex-iterate-group-iso-date 2)
+     (ledger-regex-iterate-group-note 9)
+     (ledger-regex-iterate-group-payee 8)
+     (ledger-regex-iterate-group-state 6)
+     (ledger-regex-iterate-group-year 1))))
+
 (ert-deftest ledger-regex/test-long-space ()
   (regex-test--test-regexp
    "long-space"

--- a/test/regex-test.el
+++ b/test/regex-test.el
@@ -1,0 +1,264 @@
+;;; regex-test.el --- ERT for ledger-mode  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2003-2017 John Wiegley <johnw AT gnu DOT org>
+
+;; Author: Thierry <thdox AT free DOT fr>
+;; Keywords: languages
+;; Homepage: https://github.com/ledger/ledger-mode
+
+;; This file is not part of GNU Emacs.
+
+;; Package-Requires: ((emacs "25.1"))
+
+;; This program is free software; you can redistribute it and/or modify it under
+;; the terms of the GNU General Public License as published by the Free Software
+;; Foundation; either version 2 of the License, or (at your option) any later
+;; version.
+;;
+;; This program is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;; FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+;; details.
+;;
+;; You should have received a copy of the GNU General Public License along with
+;; this program; if not, write to the Free Software Foundation, Inc., 51
+;; Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+;;  Regression tests for ledger-mode
+
+;;; Code:
+(require 'ledger-mode)
+(require 'ert)
+(require 'seq)
+(require 'subr-x)
+
+(defconst regex-test--all-ledger-regex-symbols
+  (let (result)
+    (mapatoms
+     (lambda (symbol)
+       (when (string-prefix-p "ledger-regex-" (symbol-name symbol))
+         (push symbol result))))
+    (seq-sort (lambda (a b) (string< (symbol-name a) (symbol-name b)))
+              result))
+  "List of all defined symbols that begin with `ledger-regex-'.")
+
+(defconst regex-test--ledger-define-regexp-defined-regexps
+  '("account"
+    "account-kind"
+    "amount"
+    "amount-no-group"
+    "balance-assertion"
+    "code"
+    "commoditized-amount"
+    "commodity"
+    "commodity-annotations"
+    "commodity-no-group"
+    "cost"
+    "end-note"
+    "full-account"
+    "full-amount"
+    "full-date"
+    "full-note"
+    "iso-date"
+    "long-space"
+    "note"
+    "post-line"
+    "state"
+    "xact-line")
+  "Names of the regexps defined via `ledger-define-regexp'.")
+
+(defconst regex-test--ledger-define-regexp-defined-symbols-by-name
+  (let ((hash-table (make-hash-table :test #'equal))
+        ;; Try the names in reverse, so that we try longer names before their
+        ;; prefixes.
+        (reverse-names (reverse regex-test--ledger-define-regexp-defined-regexps)))
+    ;; Add symbols in reverse so they are sorted in the correct order as we
+    ;; prepend them.
+    (dolist (symbol (reverse regex-test--all-ledger-regex-symbols))
+      (when-let (name (seq-find (lambda (name)
+                                  (string-prefix-p (concat "ledger-regex-" name "-")
+                                                   (symbol-name symbol)))
+                                reverse-names))
+        (puthash name
+                 (cons symbol (gethash name hash-table)) hash-table)))
+    hash-table)
+  "Mapping from regexp name to list of symbols defined for that regexp.")
+
+(ert-deftest ledger-regex/test-001 ()
+  "List the regexps defined by the `ledger-define-regexp' macro.
+
+When new regexps defined by that macro are added, tests should be
+added to this file similar to the tests for the other regexps."
+  (let ((ledger-define-regexp-defined-regexps
+         (seq-filter
+          #'identity
+          (seq-map
+           (lambda (symbol)
+             (when (string-match (rx (and bos "ledger-regex-" (group (* any)) "-group--count" eos))
+                                 (symbol-name symbol))
+               (match-string 1 (symbol-name symbol))))
+           regex-test--all-ledger-regex-symbols))))
+    (setq ledger-define-regexp-defined-regexps
+          (seq-sort #'string< ledger-define-regexp-defined-regexps))
+
+    (should (equal ledger-define-regexp-defined-regexps
+                   regex-test--ledger-define-regexp-defined-regexps))))
+
+(defun regex-test--dump-regex (name)
+  "Return all of the variables for the regex named NAME."
+  (seq-filter #'identity
+              (seq-map (lambda (symbol) (when (boundp symbol) (list symbol (symbol-value symbol))))
+                       (gethash name regex-test--ledger-define-regexp-defined-symbols-by-name))))
+
+(defun regex-test--test-regexp (name expected)
+  "Check that the variables associated with the regex named NAME.
+
+In particular, the group count and index variables should match EXPECTED."
+  (should (equal (regex-test--dump-regex name) expected)))
+
+(ert-deftest ledger-regex/test-account ()
+  (regex-test--test-regexp
+   "account"
+   '((ledger-regex-account-group 1)
+     (ledger-regex-account-group--count 1))))
+
+(ert-deftest ledger-regex/test-account-kind ()
+  (regex-test--test-regexp
+   "account-kind"
+   '((ledger-regex-account-kind-group 1)
+     (ledger-regex-account-kind-group--count 1))))
+
+(ert-deftest ledger-regex/test-amount ()
+  (regex-test--test-regexp
+   "amount"
+   '((ledger-regex-amount-group 1)
+     (ledger-regex-amount-group--count 1))))
+
+(ert-deftest ledger-regex/test-amount-no-group ()
+  (regex-test--test-regexp
+   "amount-no-group"
+   '((ledger-regex-amount-no-group-group 1)
+     (ledger-regex-amount-no-group-group--count 1))))
+
+(ert-deftest ledger-regex/test-balance-assertion ()
+  (regex-test--test-regexp
+   "balance-assertion"
+   '((ledger-regex-balance-assertion-group 1)
+     (ledger-regex-balance-assertion-group--count 1))))
+
+(ert-deftest ledger-regex/test-code ()
+  (regex-test--test-regexp
+   "code"
+   '((ledger-regex-code-group 1)
+     (ledger-regex-code-group--count 1))))
+
+(ert-deftest ledger-regex/test-commoditized-amount ()
+  (regex-test--test-regexp
+   "commoditized-amount"
+   '((ledger-regex-commoditized-amount-group 1)
+     (ledger-regex-commoditized-amount-group--count 1))))
+
+(ert-deftest ledger-regex/test-commodity ()
+  (regex-test--test-regexp
+   "commodity"
+   '((ledger-regex-commodity-group 1)
+     (ledger-regex-commodity-group--count 1))))
+
+(ert-deftest ledger-regex/test-commodity-annotations ()
+  (regex-test--test-regexp
+   "commodity-annotations"
+   '((ledger-regex-commodity-annotations-group 1)
+     (ledger-regex-commodity-annotations-group--count 1))))
+
+(ert-deftest ledger-regex/test-commodity-no-group ()
+  (regex-test--test-regexp
+   "commodity-no-group"
+   '((ledger-regex-commodity-no-group-group 1)
+     (ledger-regex-commodity-no-group-group--count 1))))
+
+(ert-deftest ledger-regex/test-cost ()
+  (regex-test--test-regexp
+   "cost"
+   '((ledger-regex-cost-group 1)
+     (ledger-regex-cost-group--count 1))))
+
+(ert-deftest ledger-regex/test-end-note ()
+  (regex-test--test-regexp
+   "end-note"
+   '((ledger-regex-end-note-group 1)
+     (ledger-regex-end-note-group--count 1))))
+
+(ert-deftest ledger-regex/test-full-account ()
+  (regex-test--test-regexp
+   "full-account"
+   '((ledger-regex-full-account-group--count 2)
+     (ledger-regex-full-account-group-kind 1)
+     (ledger-regex-full-account-group-name 2))))
+
+(ert-deftest ledger-regex/test-full-amount ()
+  (regex-test--test-regexp
+   "full-amount"
+   '((ledger-regex-full-amount-group 1)
+     (ledger-regex-full-amount-group--count 1))))
+
+(ert-deftest ledger-regex/test-full-date ()
+  (regex-test--test-regexp
+   "full-date"
+   '((ledger-regex-full-date-group--count 2)
+     (ledger-regex-full-date-group-actual 1)
+     (ledger-regex-full-date-group-effective 1))))
+
+(ert-deftest ledger-regex/test-full-note ()
+  (regex-test--test-regexp
+   "full-note"
+   '((ledger-regex-full-note-group 1)
+     (ledger-regex-full-note-group--count 1))))
+
+(ert-deftest ledger-regex/test-iso-date ()
+  (regex-test--test-regexp
+   "iso-date"
+   '((ledger-regex-iso-date-group 1)
+     (ledger-regex-iso-date-group--count 1))))
+
+(ert-deftest ledger-regex/test-long-space ()
+  (regex-test--test-regexp
+   "long-space"
+   '((ledger-regex-long-space-group 1)
+     (ledger-regex-long-space-group--count 1))))
+
+(ert-deftest ledger-regex/test-note ()
+  (regex-test--test-regexp
+   "note"
+   '((ledger-regex-note-group 1)
+     (ledger-regex-note-group--count 1))))
+
+(ert-deftest ledger-regex/test-post-line ()
+  (regex-test--test-regexp
+   "post-line"
+   '((ledger-regex-post-line-group--count 5)
+     (ledger-regex-post-line-group-account 3)
+     (ledger-regex-post-line-group-account-kind 2)
+     (ledger-regex-post-line-group-amount 4)
+     (ledger-regex-post-line-group-note 5)
+     (ledger-regex-post-line-group-state 1))))
+
+(ert-deftest ledger-regex/test-state ()
+  (regex-test--test-regexp
+   "state"
+   '((ledger-regex-state-group 1)
+     (ledger-regex-state-group--count 1))))
+
+(ert-deftest ledger-regex/test-xact-line ()
+  (regex-test--test-regexp
+   "xact-line"
+   '((ledger-regex-xact-line-group--count 5)
+     (ledger-regex-xact-line-group-actual-date 1)
+     (ledger-regex-xact-line-group-code 4)
+     (ledger-regex-xact-line-group-effective-date 1)
+     (ledger-regex-xact-line-group-note 5)
+     (ledger-regex-xact-line-group-state 3))))
+
+(provide 'regex-test)
+
+;;; regex-test.el ends here

--- a/test/regex-test.el
+++ b/test/regex-test.el
@@ -138,8 +138,7 @@ In particular, the group count and index variables should match EXPECTED."
 (ert-deftest ledger-regex/test-amount-no-group ()
   (regex-test--test-regexp
    "amount-no-group"
-   '((ledger-regex-amount-no-group-group 1)
-     (ledger-regex-amount-no-group-group--count 1))))
+   '((ledger-regex-amount-no-group-group--count 0))))
 
 (ert-deftest ledger-regex/test-balance-assertion ()
   (regex-test--test-regexp
@@ -175,8 +174,7 @@ In particular, the group count and index variables should match EXPECTED."
 (ert-deftest ledger-regex/test-commodity-no-group ()
   (regex-test--test-regexp
    "commodity-no-group"
-   '((ledger-regex-commodity-no-group-group 1)
-     (ledger-regex-commodity-no-group-group--count 1))))
+   '((ledger-regex-commodity-no-group-group--count 0))))
 
 (ert-deftest ledger-regex/test-cost ()
   (regex-test--test-regexp
@@ -206,7 +204,7 @@ In particular, the group count and index variables should match EXPECTED."
 (ert-deftest ledger-regex/test-full-date ()
   (regex-test--test-regexp
    "full-date"
-   '((ledger-regex-full-date-group--count 2)
+   '((ledger-regex-full-date-group--count 8)
      (ledger-regex-full-date-group-actual 1)
      (ledger-regex-full-date-group-effective 1))))
 
@@ -220,13 +218,12 @@ In particular, the group count and index variables should match EXPECTED."
   (regex-test--test-regexp
    "iso-date"
    '((ledger-regex-iso-date-group 1)
-     (ledger-regex-iso-date-group--count 1))))
+     (ledger-regex-iso-date-group--count 4))))
 
 (ert-deftest ledger-regex/test-long-space ()
   (regex-test--test-regexp
    "long-space"
-   '((ledger-regex-long-space-group 1)
-     (ledger-regex-long-space-group--count 1))))
+   '((ledger-regex-long-space-group--count 0))))
 
 (ert-deftest ledger-regex/test-note ()
   (regex-test--test-regexp
@@ -253,12 +250,12 @@ In particular, the group count and index variables should match EXPECTED."
 (ert-deftest ledger-regex/test-xact-line ()
   (regex-test--test-regexp
    "xact-line"
-   '((ledger-regex-xact-line-group--count 5)
+   '((ledger-regex-xact-line-group--count 11)
      (ledger-regex-xact-line-group-actual-date 1)
-     (ledger-regex-xact-line-group-code 4)
+     (ledger-regex-xact-line-group-code 10)
      (ledger-regex-xact-line-group-effective-date 1)
-     (ledger-regex-xact-line-group-note 5)
-     (ledger-regex-xact-line-group-state 3))))
+     (ledger-regex-xact-line-group-note 11)
+     (ledger-regex-xact-line-group-state 9))))
 
 (provide 'regex-test)
 

--- a/test/regex-test.el
+++ b/test/regex-test.el
@@ -228,12 +228,13 @@ In particular, the group count and index variables should match EXPECTED."
 (ert-deftest ledger-regex/test-iterate ()
   (regex-test--test-regexp
    "iterate"
-   '((ledger-regex-iterate-group--count 9)
-     (ledger-regex-iterate-group-code 7)
-     (ledger-regex-iterate-group-iso-date 2)
-     (ledger-regex-iterate-group-note 9)
-     (ledger-regex-iterate-group-payee 8)
-     (ledger-regex-iterate-group-state 6)
+   '((ledger-regex-iterate-group--count 13)
+     (ledger-regex-iterate-group-actual-date 2)
+     (ledger-regex-iterate-group-code 11)
+     (ledger-regex-iterate-group-effective-date 6)
+     (ledger-regex-iterate-group-note 13)
+     (ledger-regex-iterate-group-payee 12)
+     (ledger-regex-iterate-group-state 10)
      (ledger-regex-iterate-group-year 1))))
 
 (ert-deftest ledger-regex/test-long-space ()

--- a/test/xact-test.el
+++ b/test/xact-test.el
@@ -95,6 +95,37 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=526"
 "))))
 
 
+(ert-deftest ledger-xact/test-003 ()
+  "Regression test for #307
+https://github.com/ledger/ledger-mode/issues/307"
+  :tags '(xact regress)
+
+  (ledger-tests-with-temp-file
+   "2013/05/02=2013/05/03 foo
+    Expenses:Foo                            $10.00
+    Assets:Bar
+
+2013/05/03 foo
+    Expenses:Foo                            $10.00
+    Assets:Bar
+"
+   (goto-char (point-max))              ; end-of-buffer
+   (ledger-add-transaction "2013/05/01 foo")
+   (should
+    (equal (buffer-string)
+           "2013/05/01 foo
+    Expenses:Foo                              $10.00
+    Assets:Bar
+
+2013/05/02=2013/05/03 foo
+    Expenses:Foo                            $10.00
+    Assets:Bar
+
+2013/05/03 foo
+    Expenses:Foo                            $10.00
+    Assets:Bar
+"))))
+
 (provide 'xact-test)
 
 ;;; xact-test.el ends here


### PR DESCRIPTION
This pull request fixes #307.  This branch itself includes some commits from #305 and #267, but I didn't know how to express the dependency in GitHub Pull Request terms.  In any case, those should probably be reviewed first (#267 is a refactor and also includes some bugfixes).