### PR TITLE
Fix ledger-narrow-on-reconcile

### DIFF
--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -554,10 +554,10 @@ moved and recentered.  If they aren't strange things happen."
       (add-hook 'after-save-hook 'ledger-reconcile-refresh-after-save nil t)
 
       ;; Narrow the ledger buffer
+      (if ledger-narrow-on-reconcile
+          (ledger-occur account))
+
       (with-current-buffer rbuf
-        (save-excursion
-          (if ledger-narrow-on-reconcile
-              (ledger-occur account)))
         (if (> (ledger-reconcile-refresh) 0)
             (ledger-reconcile-change-target target))
         (ledger-display-balance)))))

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -555,7 +555,7 @@ moved and recentered.  If they aren't strange things happen."
 
       ;; Narrow the ledger buffer
       (if ledger-narrow-on-reconcile
-          (ledger-occur account))
+          (ledger-occur (regexp-quote account)))
 
       (with-current-buffer rbuf
         (if (> (ledger-reconcile-refresh) 0)


### PR DESCRIPTION
Fix #311 by calling ledger-occur in the main ledger buffer.  Also, we may as well regexp-quote the account name, since it may contain regexp metacharacters.