### PR TITLE
Ignore generated doc/ledger-mode.info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.elc
 *~
+/doc/ledger-mode.info


### PR DESCRIPTION
Extraordinarily minor, but this is an attempt to be friendlier to the borg package manager for emacs. Borg uses git submodules, and if you configure it to find the `doc` directory like this:

```ini
[submodule "ledger-mode"]
	path = lib/ledger-mode
	url = git@github.com:ledger/ledger-mode.git
	info-path = doc
```

then it will build the `.info` file and configure the Emacs info path to find it, so you're reading it in-place in the submodule's working directory. (It doesn't get installed elsewhere.)

But then that `.info` file sitting there makes the submodule working directory appear "dirty", so whenever we're updating submodules it has to be worked around, or added to user's global ignore file. Thanks!