### PR TITLE
Add ledger-comment-or-uncomment-current-transaction

### DIFF
--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -174,6 +174,12 @@ MOMENT is an encoded date"
     (delete-region (car bounds) (cadr bounds)))
   (delete-blank-lines))
 
+(defun ledger-comment-or-uncomment-current-transaction (pos)
+  "Comment or uncomment the transaction surrounging POS."
+  (interactive "d")
+  (let ((bounds (ledger-navigate-find-element-extents pos)))
+    (comment-or-uncomment-region (car bounds) (cadr bounds))))
+
 (defvar ledger-add-transaction-last-date nil
   "Last date entered using `ledger-read-transaction'.")
 


### PR DESCRIPTION
Add function to comment or uncomment the transaction under the cursor. Possible implementation of #315 .
