### PR TITLE
Minor documentation update

### DIFF
--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -353,8 +353,8 @@ Return the number of uncleared xacts found."
 
 (defun ledger-reconcile-finish ()
   "Mark all pending posting or transactions as cleared.
-Depends on ledger-reconcile-clear-whole-transactions, save the buffers
-and exit reconcile mode if `ledger-reconcile-finish-force-quit'"
+Depends on ledger-clear-whole-transactions, save the buffers and
+exit reconcile mode if `ledger-reconcile-finish-force-quit'"
   (interactive)
   (save-excursion
     (goto-char (point-min))


### PR DESCRIPTION
The variable `ledger-reconcile-clear-whole-transactions` does not exist. The variable `ledger-clear-whole-transactions` is what it's actually referring to.

Ran into this while I was configuring my ledger-reconcile setup for the first time, and thought I could fix this :+1: