### PR TITLE
Call ledger-reconcile-insert-effective-date in save-excursion

### DIFF
--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -228,7 +228,7 @@ date would be inserted.  If it returns non-nil, prompt for an
 effective date and insert it at point.  If it is not a function,
 do the same if its value is non-nil."
   (when (if (functionp ledger-reconcile-insert-effective-date)
-            (funcall ledger-reconcile-insert-effective-date)
+            (save-excursion (funcall ledger-reconcile-insert-effective-date))
           ledger-reconcile-insert-effective-date)
     (ledger-insert-effective-date)))
 


### PR DESCRIPTION
Thanks for merging #332, @purcell!  Just a quick follow-up because I forgot to wrap the funcall in a `save-excursion`.  I didn't judge `save-match-data` to be necessary here but I may well have missed something.