### PR TITLE
Use ledger-master-file for Flymake when available

### DIFF
--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -91,40 +91,39 @@ Flymake calls this with REPORT-FN as needed."
           ;; be simply suspended.
           (when (eq 'exit (process-status proc))
             (unwind-protect
-                 ;; Only proceed if `proc' is the same as
-                 ;; `ledger--flymake-proc', which indicates that
-                 ;; `proc' is not an obsolete process.
-                 (if (with-current-buffer source (eq proc ledger--flymake-proc))
-                     (with-current-buffer (process-buffer proc)
-                       (goto-char (point-min))
-                       ;; Parse the output buffer for diagnostic's
-                       ;; messages and locations, collect them in a list
-                       ;; of objects, and call `report-fn'.
-                       (cl-loop
-                             while (search-forward-regexp
-                                    ;; This regex needs to match the whole error.  We
-                                    ;; also need a capture group for the error message
-                                    ;; (that's group 1 here) and the line number
-                                    ;; (group 2).
-                                    (rx line-start "While parsing file \"" (one-or-more (not whitespace)) " line " (group-n 2 (one-or-more num)) ":\n"
-                                        (zero-or-more line-start "While " (one-or-more not-newline) "\n" )
-                                        (minimal-match (zero-or-more line-start (zero-or-more not-newline) "\n"))
-                                        (group-n 1 "Error: " (one-or-more not-newline) "\n"))
-                                    nil t)
-                             for msg = (match-string 1)
-                             for (beg . end) = (flymake-diag-region
-                                                source
-                                                (string-to-number (match-string 2)))
-                             for type = :error
-                             collect (flymake-make-diagnostic source
-                                                              beg
-                                                              end
-                                                              type
-                                                              msg)
-                             into diags
-                             finally (funcall report-fn diags)))
-                   (flymake-log :warning "Canceling obsolete check %s"
-                                proc))
+                ;; Only proceed if `proc' is the same as
+                ;; `ledger--flymake-proc', which indicates that
+                ;; `proc' is not an obsolete process.
+                (if (with-current-buffer source (eq proc ledger--flymake-proc))
+                    (with-current-buffer (process-buffer proc)
+                      (goto-char (point-min))
+                      ;; Parse the output buffer for diagnostic's
+                      ;; messages and locations, collect them in a list
+                      ;; of objects, and call `report-fn'.
+                      (cl-loop
+                       while (search-forward-regexp
+                              ;; This regex needs to match the whole error.  We
+                              ;; also need a capture group for the error message
+                              ;; (that's group 1 here) and the line number
+                              ;; (group 2).
+                              (rx line-start "While parsing file \"" (one-or-more (not whitespace)) " line " (group-n 2 (one-or-more num)) ":\n"
+                                  (zero-or-more line-start "While " (one-or-more not-newline) "\n" )
+                                  (minimal-match (zero-or-more line-start (zero-or-more not-newline) "\n"))
+                                  (group-n 1 "Error: " (one-or-more not-newline) "\n"))
+                              nil t)
+                       for msg = (match-string 1)
+                       for (beg . end) = (flymake-diag-region
+                                          source
+                                          (string-to-number (match-string 2)))
+                       for type = :error
+                       collect (flymake-make-diagnostic source
+                                                        beg
+                                                        end
+                                                        type
+                                                        msg)
+                       into diags
+                       finally (funcall report-fn diags)))
+                  (flymake-log :warning "Canceling obsolete check %s"
               ;; Cleanup the temporary buffer used to hold the
               ;; check's output.
               (kill-buffer (process-buffer proc))))))))))

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -68,8 +68,7 @@ Flymake calls this with REPORT-FN as needed."
   ;; Save the current buffer, the narrowing restriction, remove any
   ;; narrowing restriction.
   (let* ((source (current-buffer))
-         (master (ledger-master-file))
-         (file (if (file-exists-p master) master (buffer-file-name))))
+         (file (or (ledger-master-file) (buffer-file-name))))
     (save-restriction
       (widen)
       ;; Reset the `ledger--flymake-proc' process to a new process

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -28,6 +28,7 @@
 (require 'cl-lib)
 (require 'flymake)
 (require 'ledger-exec)                  ; for `ledger-binary-path'
+(require 'ledger-report)                ; for `ledger-master-file'
 
 ;; To silence byte compiler warnings in Emacs 25 and older:
 (declare-function flymake-diag-region "flymake" (buffer line &optional col))
@@ -66,8 +67,9 @@ Flymake calls this with REPORT-FN as needed."
     (kill-process ledger--flymake-proc))
   ;; Save the current buffer, the narrowing restriction, remove any
   ;; narrowing restriction.
-  (let ((source (current-buffer))
-        (file (buffer-file-name)))
+  (let* ((source (current-buffer))
+         (master (ledger-master-file))
+         (file (if (file-exists-p master) master (buffer-file-name))))
     (save-restriction
       (widen)
       ;; Reset the `ledger--flymake-proc' process to a new process
@@ -89,40 +91,40 @@ Flymake calls this with REPORT-FN as needed."
           ;; be simply suspended.
           (when (eq 'exit (process-status proc))
             (unwind-protect
-                ;; Only proceed if `proc' is the same as
-                ;; `ledger--flymake-proc', which indicates that
-                ;; `proc' is not an obsolete process.
-                (if (with-current-buffer source (eq proc ledger--flymake-proc))
-                    (with-current-buffer (process-buffer proc)
-                      (goto-char (point-min))
-                      ;; Parse the output buffer for diagnostic's
-                      ;; messages and locations, collect them in a list
-                      ;; of objects, and call `report-fn'.
-                      (cl-loop
-                       while (search-forward-regexp
-                              ;; This regex needs to match the whole error.  We
-                              ;; also need a capture group for the error message
-                              ;; (that's group 1 here) and the line number
-                              ;; (group 2).
-                              (rx line-start "While parsing file \"" (one-or-more (not whitespace)) " line " (group-n 2 (one-or-more num)) ":\n"
-                                  (zero-or-more line-start "While " (one-or-more not-newline) "\n" )
-                                  (minimal-match (zero-or-more line-start (zero-or-more not-newline) "\n"))
-                                  (group-n 1 "Error: " (one-or-more not-newline) "\n"))
-                              nil t)
-                       for msg = (match-string 1)
-                       for (beg . end) = (flymake-diag-region
-                                          source
-                                          (string-to-number (match-string 2)))
-                       for type = :error
-                       collect (flymake-make-diagnostic source
-                                                        beg
-                                                        end
-                                                        type
-                                                        msg)
-                       into diags
-                       finally (funcall report-fn diags)))
-                  (flymake-log :warning "Canceling obsolete check %s"
-                               proc))
+                 ;; Only proceed if `proc' is the same as
+                 ;; `ledger--flymake-proc', which indicates that
+                 ;; `proc' is not an obsolete process.
+                 (if (with-current-buffer source (eq proc ledger--flymake-proc))
+                     (with-current-buffer (process-buffer proc)
+                       (goto-char (point-min))
+                       ;; Parse the output buffer for diagnostic's
+                       ;; messages and locations, collect them in a list
+                       ;; of objects, and call `report-fn'.
+                       (cl-loop
+                             while (search-forward-regexp
+                                    ;; This regex needs to match the whole error.  We
+                                    ;; also need a capture group for the error message
+                                    ;; (that's group 1 here) and the line number
+                                    ;; (group 2).
+                                    (rx line-start "While parsing file \"" (one-or-more (not whitespace)) " line " (group-n 2 (one-or-more num)) ":\n"
+                                        (zero-or-more line-start "While " (one-or-more not-newline) "\n" )
+                                        (minimal-match (zero-or-more line-start (zero-or-more not-newline) "\n"))
+                                        (group-n 1 "Error: " (one-or-more not-newline) "\n"))
+                                    nil t)
+                             for msg = (match-string 1)
+                             for (beg . end) = (flymake-diag-region
+                                                source
+                                                (string-to-number (match-string 2)))
+                             for type = :error
+                             collect (flymake-make-diagnostic source
+                                                              beg
+                                                              end
+                                                              type
+                                                              msg)
+                             into diags
+                             finally (funcall report-fn diags)))
+                   (flymake-log :warning "Canceling obsolete check %s"
+                                proc))
               ;; Cleanup the temporary buffer used to hold the
               ;; check's output.
               (kill-buffer (process-buffer proc))))))))))

--- a/ledger-flymake.el
+++ b/ledger-flymake.el
@@ -124,6 +124,7 @@ Flymake calls this with REPORT-FN as needed."
                        into diags
                        finally (funcall report-fn diags)))
                   (flymake-log :warning "Canceling obsolete check %s"
+                               proc))
               ;; Cleanup the temporary buffer used to hold the
               ;; check's output.
               (kill-buffer (process-buffer proc))))))))))


### PR DESCRIPTION
Currently, multiple file setup ends up with incorrent linting due to `ledger-flymake` only considering the current file. In multiple file setup, where you would have your account definition separate from the actual accounting, this would lead to Flymake incorrectly linting accounts, commodities, etc as missing, when they're not. This simple change simply checks if the `(ledger-master-file)` is a file or not, and if so use it, otherwise default to using the current file.

We could make it so that the `(file-exists-p ...)` check is removed, but I don't know what is the desired behaviour in this case. Should we just assume that the user is providing the correct master file?

You could test out this feature by using the following files:

`foo.ledger`

```ledger
2023-01-01 Foo Bar
    Foo                                         -$10
    Bar

2023-01-01 Foo Baz
    Foo                                          $10
    Baz

; Local Variables:
; ledger-master-file: "main.ledger"
; End:
```

`main.ledger`

```ledger
account Foo
account Bar

commodity $
    default

include foo.ledger
```

You'll need to set `ledger-flymake-be-pedantic` to `t`. With the current change on `foo.ledger` you should be seeing a warning about the account "Baz" not being defined. If you change `ledger-master-file` to some non-existent file and restart Flymake, you should see warnings about "Foo" not being defined.