### PR TITLE
Do not add a blank line at the end of the buffer

### DIFF
--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -157,7 +157,7 @@ Leave point on the first amount."
          (encoded-date (ledger-parse-iso-date date)))
     (ledger-xact-find-slot encoded-date)
     (insert transaction
-            (if ledger-copy-transaction-insert-blank-line-after
+            (if (and ledger-copy-transaction-insert-blank-line-after (not (eobp)))
                 "\n\n"
               "\n"))
     (beginning-of-line -1)


### PR DESCRIPTION
This PR ensures that no empty lines are added to the end of the buffer when `ledger-copy-transaction-insert-blank-line-after` is `t`.