### PR TITLE
Declare ledger-post-account-alignment* variables safe

### DIFF
--- a/ledger-post.el
+++ b/ledger-post.el
@@ -37,12 +37,14 @@
 (defcustom ledger-post-account-alignment-column 4
   "The column Ledger-mode attempts to align accounts to."
   :type 'integer
-  :group 'ledger-post)
+  :group 'ledger-post
+  :safe 'integerp)
 
 (defcustom ledger-post-amount-alignment-column 52
   "The column Ledger-mode attempts to align amounts to."
   :type 'integer
-  :group 'ledger-post)
+  :group 'ledger-post
+  :safe 'integerp)
 
 (defcustom ledger-post-amount-alignment-at :end
   "Position at which the amount is aligned.
@@ -52,7 +54,8 @@ followed by unaligned commodity) or :decimal to align at the
 decimal separator."
   :type '(radio (const :tag "align at the end of amount" :end)
                 (const :tag "align at the decimal separator" :decimal))
-  :group 'ledger-post)
+  :group 'ledger-post
+  :safe (lambda (x) (memq x '(:end :decimal))))
 
 (defcustom ledger-post-auto-align t
   "When non-nil, realign post amounts when indenting or completing."


### PR DESCRIPTION
Traditionally indentation related customizations are considered safe as file local variables.