### PR TITLE
ledger-split-commodity-string: Recognize amounts less than 1

### DIFF
--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -31,10 +31,10 @@
 (defvar ledger-iso-date-regexp)
 
 (defconst ledger-amount-decimal-comma-regex
-  "-?[1-9][0-9.]*[,]?[0-9]*")
+  "-?\\(?:[1-9][0-9.]\\|0\\)*[,]?[0-9]*")
 
 (defconst ledger-amount-decimal-period-regex
-  "-?[1-9][0-9,]*[.]?[0-9]*")
+  "-?\\(?:[1-9][0-9,]*\\|0\\)[.]?[0-9]*")
 
 (defconst ledger-other-entries-regex
   "\\(^[~=A-Za-z].+\\)+")

--- a/test/reconcile-test.el
+++ b/test/reconcile-test.el
@@ -735,6 +735,17 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=262"
        (eq (1- line-before-delete) (line-number-at-pos))))))
 
 
+(ert-deftest ledger-reconcile/test-029 ()
+  "Commodity values starting with 0 are valid"
+  :tags '(reconcile regress)
+
+  (should (equal '(0.53 "$") (ledger-split-commodity-string "$0.53")))
+  (should (equal '(0.53 "USD") (ledger-split-commodity-string "0.53 USD")))
+
+  (should (equal '(-0.53 "$") (ledger-split-commodity-string "$-0.53")))
+  (should (equal '(-0.53 "USD") (ledger-split-commodity-string "-0.53 USD"))))
+
+
 (provide 'reconcile-test)
 
 ;;; reconcile-test.el ends here


### PR DESCRIPTION
Prior to this change, ledger-read-commodity-string returned strange things like `'(53 "0.")` for an input of `0.53` (with a default commodity of USD, it should have returned `'(53 "USD")`).

I decided to preserve a current property of the regexes, which is that leading zeros are still disallowed on non-zero numbers.