### PR TITLE
Add support for + and = prefixes in amount and ability to add whitespace after them

### DIFF
--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -344,7 +344,7 @@
   (note end-note))
 
 (defconst ledger-amount-regex
-  (concat "\\(  \\|\t\\| \t\\)[ \t]*[-+=]?"
+  (concat "\\(  \\|\t\\| \t\\)[ \t]*[-+=]? *"
           "\\(?:" ledger-commodity-regexp " *\\)?"
           ;; We either match just a number after the commodity with no
           ;; decimal or thousand separators or a number with thousand
@@ -352,7 +352,7 @@
           ;; or `.', because the match is non-greedy, it must leave at
           ;; least one of those symbols for the following capture
           ;; group, which then finishes the decimal part.
-          "\\([-+=]?\\(?:[0-9]+\\|[0-9,.]+?\\)\\)"
+          "\\([-+=]? *\\(?:[0-9]+\\|[0-9,.]+?\\)\\)"
           "\\([,.][0-9)]+\\)?"
           "\\(?: *" ledger-commodity-regexp "\\)?"
           "\\([ \t]*[@={]@?[^\n;]+?\\)?"

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -344,7 +344,7 @@
   (note end-note))
 
 (defconst ledger-amount-regex
-  (concat "\\(  \\|\t\\| \t\\)[ \t]*-?"
+  (concat "\\(  \\|\t\\| \t\\)[ \t]*[-+=]?"
           "\\(?:" ledger-commodity-regexp " *\\)?"
           ;; We either match just a number after the commodity with no
           ;; decimal or thousand separators or a number with thousand
@@ -352,7 +352,7 @@
           ;; or `.', because the match is non-greedy, it must leave at
           ;; least one of those symbols for the following capture
           ;; group, which then finishes the decimal part.
-          "\\(-?\\(?:[0-9]+\\|[0-9,.]+?\\)\\)"
+          "\\([-+=]?\\(?:[0-9]+\\|[0-9,.]+?\\)\\)"
           "\\([,.][0-9)]+\\)?"
           "\\(?: *" ledger-commodity-regexp "\\)?"
           "\\([ \t]*[@={]@?[^\n;]+?\\)?"


### PR DESCRIPTION
Right now postings with = and + prefixes in amount (i.e. `= 100 EUR` are not indented when pressing tab, this PR fixes that and adds ability to put spaces after these prefixes.

Indent function was changed because when we allow whitespace before prefix current indent function will just align amount including prefix meaning things like `=           100 EUR` will be left as is. I think it is better to trim this whitespace. If this breaks some expected workflow then I can make this part toggleable via config or remove it and keep it a part of my personal config.
I only tested this by checking that indent works properly and I don't know if this could affect other places