### PR TITLE
Changed comment highlighting to match the ledger file specification

### DIFF
--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -401,12 +401,14 @@
           ))
 
 (defconst ledger-posting-regex
-  (concat "^[[:blank:]]+"                 ; initial white space
-          "\\(\\([*!]\\)?"                ; state and account 1, state 2
-          "[[:blank:]]*\\(.*?\\)\\)?"     ; account 3
-          "\\(?:\\(?:\t\\|[[:blank:]]\\{2,\\}\\)" ; column separator
-          "\\([^;\n]*?\\)"                ; amount 4
-          "[[:blank:]]*\\(;.*\\)?\\)?$"   ; comment 5
+  (concat "^[[:blank:]]+" ; initial white space
+          ;; state and account, subexp 1
+          "\\(\\([*!]\\)?"            ; state,   subexp 2
+          "[[:blank:]]*\\(.*?\\)\\)?" ; account, subexp 3
+          "\\(?:\\(?:\t\\|[[:blank:]]\\{2,\\}\\)"
+          "\\([^;\n]*?\\)\\)?"        ; amount,  subexp 4
+          "\\(?:\\(?:\t\\|[[:blank:]]\\{2,\\}\\)"
+          "\\(;.*\\)\\)?$"            ; comment, subexp 5
           ))
 
 

--- a/test/fontify-test.el
+++ b/test/fontify-test.el
@@ -69,7 +69,7 @@ https://groups.google.com/d/msg/ledger-cli/FcYG5cnFOpw/PmpLq_dzdYwJ"
   (ledger-test-font-lock
    "
 2010/12/01 * Checking balance
-  Assets:Checking                   $42.00 ; the answer to life
+  Assets:Checking                   $42.00  ; the answer to life
   Equity:Opening Balances
 "
    '("2010/12/01"               ledger-font-posting-date-face
@@ -942,7 +942,7 @@ https://groups.google.com/d/msg/ledger-cli/9zyWZW_fJmk/G56uVsqv0FAJ"
       ; posting #2 note, extra indentation is optional
 
 2012-03-10 * KFC
-    Expenses:Food                $20.00 ; posting #1 note
+    Expenses:Food                $20.00  ; posting #1 note
     Assets:Cash
 "
    '("2012-03-10"                                        ledger-font-posting-date-face
@@ -2687,6 +2687,45 @@ P 2004/06/21 02:18:02 AAPL $32.91
      "Assets:Checking"          ledger-font-posting-account-face
      "$1,000.00"                ledger-font-posting-amount-face
      "Equity:Opening Balances"  ledger-font-posting-account-face)))
+
+
+(ert-deftest ledger-fontify/test-102 ()
+  "Postings with comments
+Comments must be preceded by at least one tab or two whitespace characters"
+  :tags '(font regress)
+  (ledger-test-font-lock
+   "2023/09/20 Payee
+    Assets:Checking  $1.00  ; valid comment
+    Assets:Checking  $1.00	; valid comment
+    Assets:Checking  ; valid comment
+    Assets:Checking	; valid comment
+    Assets:Checking  $1.00 ; invalid comment
+    Assets:Checking  $1.00; invalid comment
+    Assets:Checking ; invalid comment
+    Assets:Checking; invalid comment
+    Liabilities:Credit"
+   '("2023/09/20"         ledger-font-posting-date-face
+     "Payee"              ledger-font-payee-uncleared-face
+     "Assets:Checking"    ledger-font-posting-account-face
+     "$1.00"              ledger-font-posting-amount-face
+     "; valid comment"    ledger-font-comment-face
+     "Assets:Checking"    ledger-font-posting-account-face
+     "$1.00"              ledger-font-posting-amount-face
+     "; valid comment"    ledger-font-comment-face
+     "Assets:Checking"    ledger-font-posting-account-face
+     "; valid comment"    ledger-font-comment-face
+     "Assets:Checking"    ledger-font-posting-account-face
+     "; valid comment"    ledger-font-comment-face
+     "Assets:Checking  $1.00 ; invalid comment"
+                          ledger-font-posting-account-face
+     "Assets:Checking  $1.00; invalid comment"
+                          ledger-font-posting-account-face
+     "Assets:Checking ; invalid comment"
+                          ledger-font-posting-account-face
+     "Assets:Checking; invalid comment"
+                          ledger-font-posting-account-face
+     "Liabilities:Credit" ledger-font-posting-account-face)))
+
 
 (provide 'fontify-test)
 

--- a/test/reconcile-test.el
+++ b/test/reconcile-test.el
@@ -716,7 +716,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=262"
       (should ;; Expected: this must be ledger buffer
        (equal (buffer-name)           ; current buffer name
               (buffer-name ledger-buffer)))
-      (should (= 1321 (point))))))    ; expected on "Book Store" xact
+      (should (= 1322 (point))))))    ; expected on "Book Store" xact
 
 
 (ert-deftest ledger-reconcile/test-028 ()

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -68,7 +68,7 @@
   Assets:Checking
 
 2011/01/19 Grocery Store
-  Expenses:Food:Groceries             $ 44.00 ; hastag: not block
+  Expenses:Food:Groceries             $ 44.00  ; hastag: not block
   Assets:Checking
 
 2011/01/25 Bank


### PR DESCRIPTION
I changed the regex for fontifying postings so that inline comments are only fontified when they meet the ledger specification (according to [manual section 4.7.1](https://ledger-cli.org/doc/ledger3.html#Transactions-and-Comments:~:text=ACCOUNT%20%20AMOUNT%20%20%5B%3B%20NOTE%5D)).

This change has no functional impact on ledger-mode's operation, but it will help users learn proper ledger file format, ensuring that they don't run into issues with `ledger` or `ledger-mode`. If users don't put a "long space" in front of posting comments, `C-c C-b <ledger-post-edit-amount>` destroys all (or part) or the comment and places point in the wrong location.

**Rationale:**
Comments that are on the same line as a posting are supposed to have a "long space" in front of them (one tab or 2+ whitespace characters). The current code doesn't make this distinction on postings, and will highlight everything after a semi-colon as a comment.

For 4 years, I thought that posting comments were anything after a semi-colon, but that was incorrect, and the font-lock highlighting reinforces that myth.

**Other observations:**
The current comment highlighting works as intended on transaction lines and for `comment` and `test` directive blocks.  I also did not find any directly-associated issues to reference, but there are a few references to how "broken" the comment highlighting is in issues #53 and #71.

----------------

Here's what the highlighting looks like **before** my change: (two comments here are _not_ supposed to be highlighted as comments)

![screenshot of highlighting before the changes](https://github.com/ledger/ledger-mode/assets/5731041/e8f0b5d5-a7e1-4957-a77a-415671c1b795)

Here's what the highlighting looks like **after** my change: (only valid comments are highlighted as comments)

![screenshot of highlighting after the changes](https://github.com/ledger/ledger-mode/assets/5731041/90f5cd7d-b4f0-48f6-80f8-22cc1c698f13)

--------------

Here's a some raw journal content for anyone wanting to try this for themselves:
```
;; Don't forget to use M-x font-lock-fontify-buffer to refresh the highlighting!!!
2022-02-05 Payee
    ; A transaction-level comment
    Account  $1.00  ; An inline comment (2 preceding spaces)
    Account  $1.00 ; NOT an inline comment (only 1 preceding space)
    Account  $1.00; NOT an inline comment (no preceding whitespace)
    Account  $1.00    ; An inline comment (one preceding \t tab)
    Account  ; An inline comment (2 preceding spaces)
    Account ; NOT an inline comment (only 1 preceding space)
    Account; NOT an inline comment (no preceding whitespace)
    Account	; An inline comment (one preceding \t tab)    
    Liabilities
```