### PR TITLE
Added validation to `ledger-navigate-beginning-of-xact`

### DIFF
--- a/ledger-navigate.el
+++ b/ledger-navigate.el
@@ -65,15 +65,17 @@
     (re-search-backward "^[[:graph:]]" nil t)))
 
 (defun ledger-navigate-beginning-of-xact ()
-  "Move point to the beginning of the current xact."
+  "Move point to the beginning of the current transaction."
   (interactive)
-  ;; need to start at the beginning of a line in case we are in the first line of an xact already.
-  (beginning-of-line)
-  (let ((sreg (concat "^[=~[:digit:]]")))
-    (unless (looking-at sreg)
-      (re-search-backward sreg nil t)
-      (beginning-of-line)))
-  (point))
+  (if (not (ledger-point-on-valid-xact-p))
+    (user-error "Not on a valid transaction")
+    (progn
+      (beginning-of-line)
+      (let ((sreg (concat "^[=~[:digit:]]")))
+        (unless (looking-at sreg)
+          (re-search-backward sreg nil t)
+          (beginning-of-line)))
+      (point))))
 
 (defun ledger-navigate-end-of-xact ()
   "Move point to end of xact."
@@ -192,6 +194,16 @@ Requires empty line separating xacts."
       (progn (beginning-of-line)
              (point))
     (user-error "No previous uncleared transactions")))
+
+(defun ledger-point-on-valid-xact-p ()
+  "Returns t if point is located on or within a valid transaction.
+Returns nil, otherwise.
+
+Valid transactions are regular transactions, automated transactions,
+and periodic transactions."
+  (when (memq (car (ledger-context-at-point))
+              '(xact automated-xact period-xact acct-transaction))
+    t))
 
 
 (provide 'ledger-navigate)

--- a/test/navigate-test.el
+++ b/test/navigate-test.el
@@ -43,6 +43,87 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=441"
    (ledger-navigate-prev-xact-or-directive)
    (should (eq 104 (point)))))
 
+(ert-deftest ledger-navigate/test-002 ()
+  "Testing ledger-point-on-valid-xact-p"
+  :tags '(navigate baseline)
+  (ledger-tests-with-temp-file
+      "2023/09/25 Payee 1
+    Expenses  $10.00
+    Assets:Checking
+2023/09/25 * Payee 2
+    Expenses  $10.00
+    Assets:Checking
+2023/09/25 ! Payee 3
+    Expenses  $10.00
+    Assets:Checking
+= expr true
+    Expenses  $10.00
+    Assets:Checking  -$10.00
+
+~ Monthly
+    Expenses  $10.00
+    Assets:Checking  $-10.00
+tag test
+year 2023
+comment
+2023/09/25 Payee 4
+    Expenses  $10.00
+    Assets:Checking
+end comment
+;2023/09/25 Payee 5
+;    Expenses  $10.00
+;    Assets:Checking"
+    (goto-char (point-min))
+    (should (eq t (ledger-point-on-valid-xact-p))) ; Payee 1
+    (forward-line)
+    (should (eq t (ledger-point-on-valid-xact-p))) ; On a transaction posting
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq t (ledger-point-on-valid-xact-p))) ; Payee 2 (cleared)
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq t (ledger-point-on-valid-xact-p))) ; Payee 3 (pending)
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq t (ledger-point-on-valid-xact-p))) ; Automated transaction
+    (forward-line 3)
+    (should (eq nil (ledger-point-on-valid-xact-p))) ; Blank line
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq t (ledger-point-on-valid-xact-p))) ; Periodic transaction
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq nil (ledger-point-on-valid-xact-p))) ; On a tag directive
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq nil (ledger-point-on-valid-xact-p))) ; On a year directive
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq nil (ledger-point-on-valid-xact-p))) ; On a comment block directive
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq t (ledger-point-on-valid-xact-p))) ; On a transaction within a comment block
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq nil (ledger-point-on-valid-xact-p))) ; On an end-comment directive
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq nil (ledger-point-on-valid-xact-p))) ; On a ;-commented transaction
+    (ledger-navigate-next-xact-or-directive)
+    (should (eq nil (ledger-point-on-valid-xact-p))))) ; On a ;-commented transaction posting
+
+(ert-deftest ledger-navigate/test-003 ()
+  "Testing ledger-navigate-beginning-of-xact"
+  :tags '(navigate baseline)
+  (ledger-tests-with-temp-file
+      "2023/09/25 Payee
+Expenses  $10.00
+Assets:Checking
+; This line is not a valid transaction
+2023/09/25 Payee 2
+Expenses  $10.00
+Assets:Checking"
+    ;; First test that the function works on a regular transaction
+    (goto-char (point-min))
+    (forward-line 4)
+    (ledger-navigate-beginning-of-xact)
+    (should (eq 90 (point)))
+    ;; Next, test that the function does not move point when it fails
+    (forward-line -1)
+    (forward-char 2)
+    (ignore-errors (ledger-navigate-beginning-of-xact))
+    (should (eq 53 (point)))))
+
 (ert-deftest ledger-navigate-uncleared ()
   :tags '(navigate)
   (ledger-tests-with-temp-file


### PR DESCRIPTION
This implements the solution I proposed in issue #316. I've added validation to `ledger-navigate-beginning-of-xact` to keep `ledger-mode` from searching backwards indefinitely (which is the cause of erroneous deletions in #316!)