### PR TITLE
Call `ledger-next-amount` on successful `xact`

### DIFF
--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -216,15 +216,17 @@ date is requested via `ledger-read-date'."
         (when (looking-at "\n*\\'")
           (setq separator ""))))
     (if (> (length args) 1)
-        (save-excursion
-          (insert
-           (with-temp-buffer
-             (apply #'ledger-exec-ledger ledger-buf (current-buffer) "xact"
-                    (mapcar 'eval args))
-             (goto-char (point-min))
-             (ledger-post-align-postings (point-min) (point-max))
-             (buffer-string))
-           separator))
+        (progn
+          (save-excursion
+            (insert
+             (with-temp-buffer
+               (apply #'ledger-exec-ledger ledger-buf (current-buffer) "xact"
+                      (mapcar 'eval args))
+               (goto-char (point-min))
+               (ledger-post-align-postings (point-min) (point-max))
+               (buffer-string))
+             separator))
+          (ledger-next-amount))
       (progn
         (insert (car args) " ")
         (save-excursion (insert "\n" separator))))))


### PR DESCRIPTION
Hi, 
Current `C-c C-a` behavior is when user is prompted for `xact` search term and there is a similar transaction found, that transaction appears in the file like so:

```
|2023-10-17 grocery
    expenses:food                              10 AUD
    assets:debit-card
```
where `|` in the beginning is the cursor position. 
It is often the case though that amount of money I spend on groceries is different. It is actually the case for almost all transactions. 

I think it makes more sense to place cursor next to the amount so users can immediately edit it if needed. 
```
2023-10-17 grocery
    expenses:food                              |10 AUD
    assets:debit-card
```
Like so. 

ledger-mode already has `ledger-next-amount` function so I just call it in case xact returns anything.

Let me know what do you think. 