### PR TITLE
Fix bug-reference-bug-regexp to conform to its contract

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,6 +3,6 @@
 
 ((nil
   (bug-reference-url-format . "https://github.com/ledger/ledger-mode/issues/%s")
-  (bug-reference-bug-regexp . "\\(GH-?\\|[Rr]equest ?#?\\|[Bb]ug ?#?\\|[Pp]atch ?#\\|RFE ?#\\|PR [a-z-+]+/\\)\\([0-9]+\\(?:#[0-9]+\\)?\\)")
+  (bug-reference-bug-regexp . "\\(\\(?:GH-?\\|[Rr]equest ?#?\\|[Bb]ug ?#?\\|[Pp]atch ?#\\|RFE ?#\\|PR [a-z-+]+/\\)\\([0-9]+\\(?:#[0-9]+\\)?\\)\\)")
   (indent-tabs-mode . nil)
   (fill-column . 80)))


### PR DESCRIPTION
Starting in Emacs 28.1, bug-reference emits a warning if bug-reference-bug-regexp's first capture group does not contain its other capture groups (2-10).  The first capture group is used to specify which part of the buffer should be fontified as a link, and so it should include the bug number (capture group 2).