### PR TITLE
ledger-accounts-in-buffer: Don't include account subdirectives

### DIFF
--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -146,12 +146,15 @@ Then one of the elements this function returns will be
           ;; with directives.  But the name is a little misleading.  Should we
           ;; make a ledger-mode-be-pedantic and use that instead?
           (bound-and-true-p ledger-flymake-be-pedantic)
-        (goto-char (point-min))
-        (while (re-search-forward ledger-account-name-or-directive-regex nil t)
-          (let ((account (match-string-no-properties 1)))
-            (unless (gethash account seen)
-              (puthash account t seen)
-              (push (cons account nil) account-list)))))
+        (ledger-xact-iterate-transactions
+         (lambda (_pos _date _state _payee)
+           (let ((end (save-excursion (ledger-navigate-end-of-xact))))
+             (forward-line)
+             (while (re-search-forward ledger-account-name-or-directive-regex end t)
+               (let ((account (match-string-no-properties 1)))
+                 (unless (gethash account seen)
+                   (puthash account t seen)
+                   (push (cons account nil) account-list))))))))
       (sort account-list (lambda (a b) (string-lessp (car a) (car b)))))))
 
 (defun ledger-accounts-list-in-buffer ()

--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -297,6 +297,39 @@ account Assets:Checking:Bank B")
 \tExpenses\t11.99 CAD
 \tExpenses\t-11.99 CAD")))))
 
+(defvar ledger-flymake-be-pedantic)
+(defvar flycheck-ledger-pedantic)
+
+(ert-deftest ledger-complete/accounts-list-in-buffer ()
+  "https://github.com/ledger/ledger-mode/issues/380"
+  :tags '(complete regress)
+  (ledger-tests-with-temp-file
+      "\
+account Expenses:Food
+    note Use for dining out, etc.
+
+account Expenses:Groceries
+    note Use for food I cook myself
+
+2023-12-04 Restaurant
+\tExpenses:Food\t30 USD
+\tLiabilities:Credit Card
+
+2023-12-04 Grocery Store
+\tExpenses:Groceries\t50 USD
+\tLiabilities:Credit Card"
+    (let ((ledger-flymake-be-pedantic nil)
+          (flycheck-ledger-pedantic nil))
+      (should (equal (ledger-accounts-list-in-buffer)
+                     '("Expenses:Food"
+                       "Expenses:Groceries"
+                       "Liabilities:Credit Card"))))
+    (let ((ledger-flymake-be-pedantic t)
+          (flycheck-ledger-pedantic t))
+      (should (equal (ledger-accounts-list-in-buffer)
+                     '("Expenses:Food"
+                       "Expenses:Groceries"))))))
+
 (provide 'complete-test)
 
 ;;; complete-test.el ends here


### PR DESCRIPTION
Account subdirectives (like assert and note) might match the account name regex but should not be included in the list.  Instead of scanning each line in the buffer for such occurrences, only scan occurrences in transactions.

Fixes #380.