### PR TITLE
Refresh ledger-occur overlays after adding a new transaction while reconciling

### DIFF
--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -302,13 +302,15 @@ Return the number of uncleared xacts found."
         (recenter)
         (ledger-highlight-xact-under-point)))))
 
-(defun ledger-reconcile-add ()
-  "Use ledger xact to add a new transaction."
-  (interactive)
+(defun ledger-reconcile-add (date xact)
+  "Use ledger xact to add a new transaction.
+
+When called interactively, prompt for DATE, then XACT."
+  (interactive
+   (list (ledger-read-date "Date: ")
+         (read-string "Transaction: " nil 'ledger-minibuffer-history)))
   (with-current-buffer ledger-buf
-    (let ((date (ledger-read-date "Date: "))
-          (text (read-string "Transaction: " nil 'ledger-minibuffer-history)))
-      (ledger-add-transaction (concat date " " text))))
+    (ledger-add-transaction (concat date " " xact)))
   (ledger-reconcile-refresh))
 
 (defun ledger-reconcile-delete ()

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -508,7 +508,6 @@ Return a count of the uncleared transactions."
 This is achieved by placing that transaction at the bottom of the main window.
 The key to this is to ensure the window is selected when the buffer point is
 moved and recentered.  If they aren't strange things happen."
-
   (let ((reconcile-window (get-buffer-window (get-buffer ledger-reconcile-buffer-name))))
     (when reconcile-window
       (fit-window-to-buffer reconcile-window)
@@ -519,6 +518,9 @@ moved and recentered.  If they aren't strange things happen."
         (recenter))
       (select-window reconcile-window)
       (ledger-reconcile-visit t))
+    (with-current-buffer ledger-buf
+      (when ledger-occur-mode
+        (ledger-occur-refresh)))
     (add-hook 'post-command-hook 'ledger-reconcile-track-xact nil t)))
 
 (defun ledger-reconcile-track-xact ()

--- a/test/input/demo.ledger
+++ b/test/input/demo.ledger
@@ -1,0 +1,63 @@
+2010/12/01 * Checking balance
+  Assets:Checking                   $1,000.00
+  Equity:Opening Balances
+
+2010/12/20 * Organic Co-op
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/01/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/02/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/03/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/04/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/05/01]
+  Expenses:Food:Groceries             $ 37.50  ; [=2011/06/01]
+  Assets:Checking                   $ -225.00
+
+2010/12/28 Acme Mortgage
+  Liabilities:Mortgage:Principal    $  200.00
+  Expenses:Interest:Mortgage        $  500.00
+  Expenses:Escrow                   $  300.00
+  * Assets:Checking                $ -1000.00
+
+2011/01/02 Grocery Store
+  Expenses:Food:Groceries             $ 65.00
+  * Assets:Checking
+
+2011/01/05 Employer
+  * Assets:Checking                 $ 2000.00
+  Income:Salary
+
+2011/01/14 Bank
+  ; Regular monthly savings transfer
+  Assets:Savings                     $ 300.00
+  Assets:Checking
+
+2011/01/19 Grocery Store
+  Expenses:Food:Groceries             $ 44.00  ; hastag: not block
+  Assets:Checking
+
+2011/01/25 Bank
+  ; Transfer to cover car purchase
+  Assets:Checking                  $ 5,500.00
+  Assets:Savings
+  ; :nobudget:
+
+2011/01/25 Tom's Used Cars
+  Expenses:Auto                    $ 5,500.00
+  ; :nobudget:
+  Assets:Checking
+
+2011/01/27 Book Store
+  Expenses:Books                       $20.00
+  Liabilities:MasterCard
+
+2011/04/25 Tom's Used Cars
+  Expenses:Auto                    $ 5,500.00
+  ; :nobudget:
+  Assets:Checking
+
+2011/04/27 Bookstore
+  Expenses:Books                       $20.00
+  Assets:Checking
+
+2011/12/01 Sale
+  Assets:Checking                     $ 30.00
+  Income:Sales

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -31,74 +31,13 @@
 (require 'cl-lib)
 (require 'cus-edit)
 
-(defvar demo-ledger)
-
-;; FIXME instead of setting the string, load the content from file
-;; ../test/input/demo.ledger
-(setq demo-ledger "2010/12/01 * Checking balance
-  Assets:Checking                   $1,000.00
-  Equity:Opening Balances
-
-2010/12/20 * Organic Co-op
-  Expenses:Food:Groceries             $ 37.50  ; [=2011/01/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2011/02/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2011/03/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2011/04/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2011/05/01]
-  Expenses:Food:Groceries             $ 37.50  ; [=2011/06/01]
-  Assets:Checking                   $ -225.00
-
-2010/12/28 Acme Mortgage
-  Liabilities:Mortgage:Principal    $  200.00
-  Expenses:Interest:Mortgage        $  500.00
-  Expenses:Escrow                   $  300.00
-  * Assets:Checking                $ -1000.00
-
-2011/01/02 Grocery Store
-  Expenses:Food:Groceries             $ 65.00
-  * Assets:Checking
-
-2011/01/05 Employer
-  * Assets:Checking                 $ 2000.00
-  Income:Salary
-
-2011/01/14 Bank
-  ; Regular monthly savings transfer
-  Assets:Savings                     $ 300.00
-  Assets:Checking
-
-2011/01/19 Grocery Store
-  Expenses:Food:Groceries             $ 44.00  ; hastag: not block
-  Assets:Checking
-
-2011/01/25 Bank
-  ; Transfer to cover car purchase
-  Assets:Checking                  $ 5,500.00
-  Assets:Savings
-  ; :nobudget:
-
-2011/01/25 Tom's Used Cars
-  Expenses:Auto                    $ 5,500.00
-  ; :nobudget:
-  Assets:Checking
-
-2011/01/27 Book Store
-  Expenses:Books                       $20.00
-  Liabilities:MasterCard
-
-2011/04/25 Tom's Used Cars
-  Expenses:Auto                    $ 5,500.00
-  ; :nobudget:
-  Assets:Checking
-
-2011/04/27 Bookstore
-  Expenses:Books                       $20.00
-  Assets:Checking
-
-2011/12/01 Sale
-  Assets:Checking                     $ 30.00
-  Income:Sales
-")
+(defvar demo-ledger
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name
+      "input/demo.ledger"
+      (file-name-directory load-file-name)))
+    (buffer-string)))
 
 
 (defun ledger-tests-reset-custom-values (group)


### PR DESCRIPTION
Refresh ledger-occur overlays after ledger-reconcile-add

Fix #383.

This PR also includes a couple of drive-by refactors.