### PR TITLE
Rename ledger-recon-buffer-name to be consistent

### DIFF
--- a/doc/ledger-mode.texi
+++ b/doc/ledger-mode.texi
@@ -993,7 +993,7 @@ If non-nil, highlight transaction under point using
 
 @ftable @option
 
-@item ledger-recon-buffer-name
+@item ledger-reconcile-buffer-name
 Name to use for reconciliation buffer. Defaults to @file{*Reconcile*}.
 
 @item ledger-narrow-on-reconcile
@@ -1018,7 +1018,7 @@ Date format for the reconcile buffer. Defaults to
 @option{ledger-default-date-format}.
 
 @item ledger-reconcile-target-prompt-string
-Prompt for recon target. Defaults to "Target amount for reconciliation ".
+Prompt for reconcile target. Defaults to "Target amount for reconciliation ".
 
 @item ledger-reconcile-buffer-header
 Header string for the reconcile buffer. If non-nil, the name of the

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -49,7 +49,12 @@
   "Options for Ledger-mode reconciliation"
   :group 'ledger)
 
-(defcustom ledger-recon-buffer-name "*Reconcile*"
+(define-obsolete-variable-alias
+  'ledger-recon-buffer-name
+  'ledger-reconcile-buffer-name
+  "2023-12-15")
+
+(defcustom ledger-reconcile-buffer-name "*Reconcile*"
   "Name to use for reconciliation buffer."
   :type 'string
   :group 'ledger-reconcile)
@@ -84,7 +89,7 @@ Default is `ledger-default-date-format'."
   :group 'ledger-reconcile)
 
 (defcustom ledger-reconcile-target-prompt-string "Target amount for reconciliation "
-  "Prompt for recon target."
+  "Prompt for reconcile target."
   :type 'string
   :group 'ledger-reconcile)
 
@@ -233,7 +238,7 @@ do the same if its value is non-nil."
     (ledger-insert-effective-date)))
 
 (defun ledger-reconcile-toggle ()
-  "Toggle the current transaction, and mark the recon window."
+  "Toggle the current transaction, and mark the reconcile window."
   (interactive)
   (beginning-of-line)
   (let ((where (get-text-property (point) 'where))
@@ -283,12 +288,12 @@ Return the number of uncleared xacts found."
       (forward-line line))))
 
 (defun ledger-reconcile-refresh-after-save ()
-  "Refresh the recon-window after the ledger buffer is saved."
+  "Refresh the reconcile window after the ledger buffer is saved."
   (let ((curbufwin (get-buffer-window (current-buffer)))
         (curpoint (point))
-        (recon-buf (get-buffer ledger-recon-buffer-name)))
-    (when (buffer-live-p recon-buf)
-      (with-current-buffer recon-buf
+        (reconcile-buf (get-buffer ledger-reconcile-buffer-name)))
+    (when (buffer-live-p reconcile-buf)
+      (with-current-buffer reconcile-buf
         (ledger-reconcile-refresh)
         (set-buffer-modified-p nil))
       (when curbufwin
@@ -307,7 +312,7 @@ Return the number of uncleared xacts found."
   (ledger-reconcile-refresh))
 
 (defun ledger-reconcile-delete ()
-  "Delete the transactions pointed to in the recon window."
+  "Delete the transactions pointed to in the reconcile window."
   (interactive)
   (let ((where (get-text-property (point) 'where)))
     (when (ledger-reconcile-get-buffer where)
@@ -329,7 +334,7 @@ Return the number of uncleared xacts found."
          (target-buffer (if where
                             (ledger-reconcile-get-buffer where)
                           nil))
-         (cur-win (get-buffer-window (get-buffer ledger-recon-buffer-name))))
+         (cur-win (get-buffer-window (get-buffer ledger-reconcile-buffer-name))))
     (when target-buffer
       (switch-to-buffer-other-window target-buffer)
       (ledger-navigate-to-line (cdr where))
@@ -339,7 +344,7 @@ Return the number of uncleared xacts found."
       (forward-char -1)
       (when (and come-back cur-win)
         (select-window cur-win)
-        (get-buffer ledger-recon-buffer-name)))))
+        (get-buffer ledger-reconcile-buffer-name)))))
 
 
 (defun ledger-reconcile-save ()
@@ -374,16 +379,16 @@ exit reconcile mode if `ledger-reconcile-finish-force-quit'"
 (defun ledger-reconcile-quit ()
   "Quit the reconcile window without saving ledger buffer."
   (interactive)
-  (let ((recon-buf (get-buffer ledger-recon-buffer-name))
+  (let ((reconcile-buf (get-buffer ledger-reconcile-buffer-name))
         buf)
-    (if recon-buf
-        (with-current-buffer recon-buf
+    (if reconcile-buf
+        (with-current-buffer reconcile-buf
           (ledger-reconcile-quit-cleanup)
           (setq buf ledger-buf)
           ;; Make sure you delete the window before you delete the buffer,
           ;; otherwise, madness ensues
-          (delete-window (get-buffer-window recon-buf))
-          (kill-buffer recon-buf)
+          (delete-window (get-buffer-window reconcile-buf))
+          (kill-buffer reconcile-buf)
           (set-window-buffer (selected-window) buf)))))
 
 (defun ledger-reconcile-quit-cleanup ()
@@ -502,15 +507,15 @@ This is achieved by placing that transaction at the bottom of the main window.
 The key to this is to ensure the window is selected when the buffer point is
 moved and recentered.  If they aren't strange things happen."
 
-  (let ((recon-window (get-buffer-window (get-buffer ledger-recon-buffer-name))))
-    (when recon-window
-      (fit-window-to-buffer recon-window)
+  (let ((reconcile-window (get-buffer-window (get-buffer ledger-reconcile-buffer-name))))
+    (when reconcile-window
+      (fit-window-to-buffer reconcile-window)
       (with-current-buffer ledger-buf
         (add-hook 'kill-buffer-hook 'ledger-reconcile-quit nil t)
         (if (get-buffer-window ledger-buf)
             (select-window (get-buffer-window ledger-buf)))
         (recenter))
-      (select-window recon-window)
+      (select-window reconcile-window)
       (ledger-reconcile-visit t))
     (add-hook 'post-command-hook 'ledger-reconcile-track-xact nil t)))
 
@@ -545,7 +550,7 @@ moved and recentered.  If they aren't strange things happen."
   (interactive)
   (let ((account (or account (ledger-read-account-with-prompt "Account to reconcile")))
         (buf (current-buffer))
-        (rbuf (get-buffer ledger-recon-buffer-name)))
+        (rbuf (get-buffer ledger-reconcile-buffer-name)))
 
     (when (ledger-reconcile-check-valid-account account)
       (if rbuf ;; *Reconcile* already exists
@@ -559,10 +564,10 @@ moved and recentered.  If they aren't strange things happen."
             (unless (get-buffer-window rbuf)
               (ledger-reconcile-open-windows buf rbuf)))
 
-        ;; no recon-buffer, starting from scratch.
+        ;; no reconcile-buffer, starting from scratch.
 
         (with-current-buffer (setq rbuf
-                                   (get-buffer-create ledger-recon-buffer-name))
+                                   (get-buffer-create ledger-reconcile-buffer-name))
           (ledger-reconcile-open-windows buf rbuf)
           (ledger-reconcile-mode)
           (make-local-variable 'ledger-target)

--- a/test/reconcile-test.el
+++ b/test/reconcile-test.el
@@ -36,15 +36,15 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=1107"
 
   (ledger-tests-with-temp-file
       demo-ledger
-    (ledger-reconcile "Assets:Checking" '(0 "$")) ; this moves to *recon* buffer
+    (ledger-reconcile "Assets:Checking" '(0 "$")) ; this moves to *reconcile* buffer
     (other-window 1)                ; go to *ledger* buffer
     (insert " ")                    ; simulate modification of ledger buffer
     (delete-char -1)
     (other-window 1)                ; back to *reconcile* buffer
     (ledger-reconcile-save)         ; key 's'
-    (should ;; current buffer should be *recon* buffer
+    (should ;; current buffer should be *reconcile* buffer
      (equal (buffer-name)           ; current buffer name
-            ledger-recon-buffer-name))
+            ledger-reconcile-buffer-name))
     (other-window 1)                ; switch to *other* window
     (should ;; Expected: this must be ledger buffer
      (equal (buffer-name)           ; current buffer name
@@ -60,13 +60,13 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=1039"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (forward-line 2)                    ; because of ledger-reconcile-buffer-header
     (ledger-reconcile-toggle)                     ; mark pending
     (ledger-reconcile-toggle)                     ; mark pending
     (ledger-reconcile-finish)                     ; C-c C-c
-    (should ;; Expected: buffer recon must still exist and be selected
-     (equal ledger-recon-buffer-name
+    (should ;; Expected: buffer reconcile must still exist and be selected
+     (equal ledger-reconcile-buffer-name
             (buffer-name (window-buffer (selected-window)))))))
 
 
@@ -74,20 +74,20 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=1039"
   "Regress test for Bug 1060
 http://bugs.ledger-cli.org/show_bug.cgi?id=1060
 
-If `ledger-reconcile-finish-force-quit' is set, recon window is killed"
+If `ledger-reconcile-finish-force-quit' is set, reconcile window is killed"
   :tags '(reconcile regress)
 
   (ledger-tests-with-temp-file
       demo-ledger
     (setq ledger-reconcile-finish-force-quit t)
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (forward-line 2)                    ; because of ledger-reconcile-buffer-header
     (ledger-reconcile-toggle)                     ; mark pending
     (ledger-reconcile-toggle)                     ; mark pending
     (ledger-reconcile-finish)                     ; C-c C-c
-    (should ;; Expected: recon buffer has been killed
-     (equal nil (get-buffer-window ledger-recon-buffer-name)))))
+    (should ;; Expected: reconcile buffer has been killed
+     (equal nil (get-buffer-window ledger-reconcile-buffer-name)))))
 
 
 (ert-deftest ledger-reconcile/test-004 ()
@@ -134,7 +134,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=875"
           ledger-reconcile-buffer-payee-max-chars 30
           ledger-reconcile-buffer-account-max-chars 22)
     (ledger-reconcile "Expenses:Food:Groceries" '(0 "$"))
-    (switch-to-buffer ledger-recon-buffer-name)
+    (switch-to-buffer ledger-reconcile-buffer-name)
     (should (equal
              "2008/10/16 Bountiful Blessings Farm Will… …penses:Food:Groceries    $ 37.50
 2008/10/16 Bountiful Blessings Farm Will… …penses:Food:Groceries    $ 37.50
@@ -155,7 +155,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=1104"
     (setq ledger-reconcile-buffer-header "")
     (ledger-reconcile "Expenses:Books" '(0 "$"))
     (should-not
-     (equal nil (get-buffer-window ledger-recon-buffer-name)))))
+     (equal nil (get-buffer-window ledger-reconcile-buffer-name)))))
 
 
 (ert-deftest ledger-reconcile/test-007 ()
@@ -200,8 +200,8 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=1056"
 "
     (setq ledger-reconcile-default-commodity "€") ; FIXME This must be set even if below call (ledger-reconcile "Dépense" '(0 "€")) is using "€". Is this a bug?
     (ledger-reconcile "Dépense" '(0 "€"))
-    (should-not ;; ledger recon must exists and no error prevented to go to this point
-     (equal nil (get-buffer-window ledger-recon-buffer-name)))))
+    (should-not ;; ledger reconcile must exists and no error prevented to go to this point
+     (equal nil (get-buffer-window ledger-reconcile-buffer-name)))))
 
 
 (ert-deftest ledger-reconcile/test-009 ()
@@ -213,7 +213,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=915"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (forward-line 6)
     (ledger-reconcile-toggle)
     (ledger-reconcile-toggle)
@@ -221,9 +221,9 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=915"
       (ledger-reconcile-save)             ; key 's'
       (should ;; Expected: line position is kept
        (eq line-before-save (line-number-at-pos)))
-      (should ;; current buffer should be *recon* buffer
+      (should ;; current buffer should be *reconcile* buffer
        (equal (buffer-name)           ; current buffer name
-              ledger-recon-buffer-name)))))
+              ledger-reconcile-buffer-name)))))
 
 
 (ert-deftest ledger-reconcile/test-010 ()
@@ -235,7 +235,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=986"
       demo-ledger
 
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (should
      (equal (buffer-string)     ; default sort is by ledger file order
       "Reconciling account Assets:Checking
@@ -251,7 +251,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=986"
 
     (setq ledger-reconcile-sort-key "(date)") ; sort by date
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (should
      (equal (buffer-string)
       "Reconciling account Assets:Checking
@@ -267,7 +267,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=986"
 
     (setq ledger-reconcile-sort-key "(amount)") ; sort by amount
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (should
      (equal (buffer-string)             ; sort by ledger file order
       "Reconciling account Assets:Checking
@@ -283,7 +283,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=986"
 
     (setq ledger-reconcile-sort-key "(payee)") ; sort by payee
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (should
      (equal (buffer-string)
       "Reconciling account Assets:Checking
@@ -299,7 +299,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=986"
 
     (setq ledger-reconcile-sort-key "(0)") ; sort by ledger file order
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (should
      (equal (buffer-string)
       "Reconciling account Assets:Checking
@@ -322,13 +322,13 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=967"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (other-window 1)                ; go to *ledger* buffer
     (remove-hook 'kill-buffer-hook 'ledger-reconcile-quit t) ; needed for delete-other-windows
     (delete-other-windows)          ; C-x 1
     (set-frame-width (selected-frame) 100) ; needed for split-window-right
     (split-window-right)            ; C-x 3
-    (switch-to-buffer-other-window ledger-recon-buffer-name) ; C-x 4 b
+    (switch-to-buffer-other-window ledger-reconcile-buffer-name) ; C-x 4 b
 
     (forward-line 2)
     (ledger-reconcile-toggle)
@@ -359,7 +359,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=957"
 "
     (setq ledger-reconcile-default-commodity "€")
     (ledger-reconcile "BanqueAccord" '(0 "€"))
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (forward-line 2)
     (ledger-reconcile-visit)
     (forward-line -1)
@@ -369,7 +369,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=957"
     Dépense:Alimentation:Alcool    1,00 €
 ")
     (save-buffer)
-    (switch-to-buffer-other-window ledger-recon-buffer-name)
+    (switch-to-buffer-other-window ledger-reconcile-buffer-name)
     (ledger-reconcile-toggle)
     (switch-to-buffer-other-window ledger-buffer)
     (should
@@ -390,7 +390,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=957"
     (forward-line 1)
     (kill-line 4)
     (save-buffer)
-    (switch-to-buffer-other-window ledger-recon-buffer-name)
+    (switch-to-buffer-other-window ledger-reconcile-buffer-name)
     (forward-line -1)
     (ledger-reconcile-toggle)
     (switch-to-buffer-other-window ledger-buffer)
@@ -415,13 +415,13 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=906"
       demo-ledger
     (goto-char 1040)
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (switch-to-buffer-other-window ledger-buffer)
     (should (= 1040 (point)))
 
     (goto-char 1265)
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (switch-to-buffer-other-window ledger-buffer)
     (should (= 1265 (point)))))
 
@@ -434,7 +434,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=900"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Assets:Checking" '(0 "$"))
-    (select-window (get-buffer-window ledger-recon-buffer-name))
+    (select-window (get-buffer-window ledger-reconcile-buffer-name))
     (switch-to-buffer-other-window ledger-buffer)
     (save-buffer)
     (let ((ledger-buffer-name (buffer-name ledger-buffer)))
@@ -453,7 +453,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=245"
   (ledger-tests-with-temp-file          ; Faces in *Reconcile* buffer
       demo-ledger
     (ledger-reconcile "Assets:Checking" '(0 "$"))
-    (select-window (get-buffer-window ledger-recon-buffer-name))
+    (select-window (get-buffer-window ledger-reconcile-buffer-name))
     (forward-line 2)       ; because of ledger-reconcile-buffer-header
     (should (eq 'ledger-font-reconciler-uncleared-face
                 (get-text-property (point) 'font-lock-face)))
@@ -470,7 +470,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=245"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Assets:Checking" '(0 "$"))
-    (select-window (get-buffer-window ledger-recon-buffer-name))
+    (select-window (get-buffer-window ledger-reconcile-buffer-name))
     (forward-line 2)       ; because of ledger-reconcile-buffer-header
     (ledger-reconcile-toggle)           ; mark pending
     (forward-line 1)
@@ -488,7 +488,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=895"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Food" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (should
      (equal (buffer-string)
       "Reconciling account Food
@@ -505,7 +505,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=886"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Assets:Checking" '(0 "$"))
-    (select-window (get-buffer-window ledger-recon-buffer-name))
+    (select-window (get-buffer-window ledger-reconcile-buffer-name))
     (goto-char (point-max))  ; end-of-buffer
     (let ((line-before-toggle (line-number-at-pos)))
       (ledger-reconcile-toggle)           ; mark pending
@@ -526,13 +526,13 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=879"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-recon-buffer-name)) ; IRL user select recon window
+    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
     (switch-to-buffer-other-window ledger-buffer)
     (ledger-reconcile "Food" '(0 "$")) ; launch a *second* time on *another* account
-    (select-window (get-buffer-window ledger-recon-buffer-name))
-    (should ;; current buffer should be *recon* buffer
+    (select-window (get-buffer-window ledger-reconcile-buffer-name))
+    (should ;; current buffer should be *reconcile* buffer
      (equal (buffer-name)           ; current buffer name
-            ledger-recon-buffer-name))
+            ledger-reconcile-buffer-name))
     (other-window 1)                ; switch to *other* window
     (should ;; Expected: this must be ledger buffer
      (equal (buffer-name)           ; current buffer name
@@ -550,7 +550,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=527"
     Assets:Checking
 "
    (ledger-reconcile "Expenses:Food" '(0 "$"))
-   (switch-to-buffer ledger-recon-buffer-name)
+   (switch-to-buffer ledger-reconcile-buffer-name)
    (should (equal
             "Reconciling account Expenses:Food
 
@@ -574,7 +574,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=922"
 "
    (setq ledger-reconcile-buffer-header "")
    (ledger-reconcile "Nyu" '(0 "B"))
-   (switch-to-buffer ledger-recon-buffer-name)
+   (switch-to-buffer ledger-reconcile-buffer-name)
    (should (equal (buffer-string)
             "2012/01/02 03DIZ3Q Bilip                                              Nyu:sto                                  -12 B"))))
 
@@ -590,7 +590,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=951"
     Assets:Checking
 "
    (ledger-reconcile "Expenses:Food" '(0 "$"))
-   (switch-to-buffer ledger-recon-buffer-name)
+   (switch-to-buffer ledger-reconcile-buffer-name)
    (should (equal (buffer-string)
             "Reconciling account Expenses:Food
 
@@ -628,7 +628,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=396"
     Assets:Checking
 "
    (ledger-reconcile "Expenses:Food" '(0 "$"))
-   (switch-to-buffer ledger-recon-buffer-name)
+   (switch-to-buffer ledger-reconcile-buffer-name)
    (should (equal (buffer-string)
                   "Reconciling account Expenses:Food
 
@@ -702,16 +702,16 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=262"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Expenses" '(0 "$"))
-    (select-window (get-buffer-window ledger-recon-buffer-name))
+    (select-window (get-buffer-window ledger-reconcile-buffer-name))
     (forward-line 2)       ; because of ledger-reconcile-buffer-header
-    (forward-line 4)       ; move to not be on first line of recon
+    (forward-line 4)       ; move to not be on first line of reconcile
     (let ((line-before-delete (line-number-at-pos)))
       (ledger-reconcile-delete)             ; key 'd'
       (should ;; Expected: line position is kept
        (eq line-before-delete (line-number-at-pos)))
-      (should ;; current buffer should be *recon* buffer
+      (should ;; current buffer should be *reconcile* buffer
        (equal (buffer-name)           ; current buffer name
-              ledger-recon-buffer-name))
+              ledger-reconcile-buffer-name))
       (other-window 1)                ; switch to *other* window
       (should ;; Expected: this must be ledger buffer
        (equal (buffer-name)           ; current buffer name
@@ -726,7 +726,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=262"
   (ledger-tests-with-temp-file
       demo-ledger
     (ledger-reconcile "Expenses" '(0 "$"))
-    (select-window (get-buffer-window ledger-recon-buffer-name))
+    (select-window (get-buffer-window ledger-reconcile-buffer-name))
     (goto-char (point-max))             ; end-of-buffer
     (goto-char (line-beginning-position)) ; beginning-of-line
     (let ((line-before-delete (line-number-at-pos)))


### PR DESCRIPTION
Also replace "recon" in docstrings and variable names with "reconcile".