### PR TITLE
Rework ledger-post-edit-amount

### DIFF
--- a/ledger-post.el
+++ b/ledger-post.el
@@ -163,26 +163,25 @@ regular text."
 (defun ledger-post-edit-amount ()
   "Call `calc-mode' and push the amount in the posting to the top of stack."
   (interactive)
-  (goto-char (line-beginning-position))
+  (beginning-of-line)
   (when (re-search-forward ledger-post-line-regexp (line-end-position) t)
-    (goto-char (match-end ledger-regex-post-line-group-account)) ;; go to the and of the account
-    (let ((end-of-amount (re-search-forward ledger-amount-regexp (line-end-position) t)))
-      ;; determine if there is an amount to edit
-      (if end-of-amount
-          (let ((val-string (match-string 0)))
-            (goto-char (match-beginning 0))
-            (delete-region (match-beginning 0) (match-end 0))
-            (push-mark (point) 'nomsg)
-            (calc)
-            ;; edit the amount, first removing thousands separators and
-            ;; converting decimal commas to calc's input format
-            (calc-eval (number-to-string (ledger-string-to-number val-string)) 'push))
-        (progn ;;make sure there are two spaces after the account name and go to calc
-          (if (search-backward "  " (- (point) 3) t)
-              (goto-char (line-end-position))
-            (insert "  "))
+    (goto-char (match-end ledger-regex-post-line-group-account)) ;; go to the end of the account
+    ;; determine if there is an amount to edit
+    (if (re-search-forward ledger-amount-regexp (line-end-position) t)
+        (let ((val-string (match-string 0)))
+          (goto-char (match-beginning 0))
+          (delete-region (match-beginning 0) (match-end 0))
           (push-mark (point) 'nomsg)
-          (calc))))))
+          (calc)
+          ;; edit the amount, first removing thousands separators and converting
+          ;; decimal commas to calc's input format
+          (calc-eval (number-to-string (ledger-string-to-number val-string)) 'push))
+      ;; make sure there are two spaces after the account name and go to calc
+      (if (search-backward "  " (- (point) 3) t)
+          (end-of-line)
+        (insert "  "))
+      (push-mark (point) 'nomsg)
+      (calc))))
 
 (provide 'ledger-post)
 

--- a/ledger-post.el
+++ b/ledger-post.el
@@ -166,7 +166,7 @@ regular text."
   (goto-char (line-beginning-position))
   (when (re-search-forward ledger-post-line-regexp (line-end-position) t)
     (goto-char (match-end ledger-regex-post-line-group-account)) ;; go to the and of the account
-    (let ((end-of-amount (re-search-forward "[-.,0-9]+" (line-end-position) t)))
+    (let ((end-of-amount (re-search-forward ledger-amount-regexp (line-end-position) t)))
       ;; determine if there is an amount to edit
       (if end-of-amount
           (let ((val-string (match-string 0)))

--- a/ledger-post.el
+++ b/ledger-post.el
@@ -181,7 +181,14 @@ regular text."
           (end-of-line)
         (insert "  "))
       (push-mark (point) 'nomsg)
-      (calc))))
+      (calc))
+
+    ;; Preserve calc's own welcome message, if any, and append our own.
+    (message "%s%s"
+             (if-let (msg (current-message))
+                 (concat msg "\n\n")
+               "")
+             (substitute-command-keys "Press \\[universal-argument] \\[calc-copy-to-buffer] to use the top of stack as the new amount."))))
 
 (provide 'ledger-post)
 

--- a/ledger-post.el
+++ b/ledger-post.el
@@ -172,7 +172,7 @@ regular text."
           (let ((val-string (match-string 0)))
             (goto-char (match-beginning 0))
             (delete-region (match-beginning 0) (match-end 0))
-            (push-mark)
+            (push-mark (point) 'nomsg)
             (calc)
             ;; edit the amount, first removing thousands separators and
             ;; converting decimal commas to calc's input format
@@ -181,7 +181,7 @@ regular text."
           (if (search-backward "  " (- (point) 3) t)
               (goto-char (line-end-position))
             (insert "  "))
-          (push-mark)
+          (push-mark (point) 'nomsg)
           (calc))))))
 
 (provide 'ledger-post)

--- a/ledger-post.el
+++ b/ledger-post.el
@@ -161,7 +161,7 @@ regular text."
    (t (call-interactively 'ledger-post-align-xact))))
 
 (defun ledger-post-edit-amount ()
-  "Call `calc-mode' and push the amount in the posting to the top of stack."
+  "Call `calc' and push the amount in the posting to the top of stack, if any."
   (interactive)
   (beginning-of-line)
   (when (re-search-forward ledger-post-line-regexp (line-end-position) t)

--- a/ledger-regex.el
+++ b/ledger-regex.el
@@ -282,7 +282,7 @@
 (ledger-define-regexp amount-no-group
   (rx (and (? ?-)
            (+ digit)
-           (*? (and (any ?. ?,) (+ digit)))))
+           (* (and (any ?. ?,) (+ digit)))))
   "")
 
 (ledger-define-regexp amount


### PR DESCRIPTION
I originally just wanted to add a small docstring tweak and suppress the "Mark
set" message from this command, but this PR also includes some drive-by
refactors.

Also, add a hint to the Calc welcome message suggesting the user to press C-u y,
which will insert the top stack value into the ledger buffer and close calc.