### PR TITLE
reconcile: Optionally display balance in header line

### DIFF
--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -288,6 +288,7 @@ Return the number of uncleared xacts found."
         (ledger-do-reconcile ledger-reconcile-sort-key)
       (set-buffer-modified-p t)
       (ledger-reconcile-ensure-xacts-visible)
+      (ledger-display-balance)
       (goto-char (point-min))
       (forward-line line))))
 
@@ -301,7 +302,7 @@ Return the number of uncleared xacts found."
         (ledger-reconcile-refresh)
         (set-buffer-modified-p nil))
       (when curbufwin
-        (select-window  curbufwin)
+        (select-window curbufwin)
         (goto-char curpoint)
         (recenter)
         (ledger-highlight-xact-under-point)))))


### PR DESCRIPTION
This commit adds a new customization,
`ledger-reconcile-display-balance-in-header`.  If non-nil, this causes the
reconcile buffer's header line to display the cleared+pending balance, as well
as the difference from target (if any), continuously while reconciling.  I have
found this far more convenient than searching through `*Messages*` for the last
balance message (although I learned that `ledger-display-balance` has a key
binding while implementing this, I still think this feature may be useful).