### PR TITLE
Fix calc-window-height decreasing each time ledger-post-edit-amount is called

### DIFF
--- a/ledger-post.el
+++ b/ledger-post.el
@@ -161,7 +161,10 @@ regular text."
    (t (call-interactively 'ledger-post-align-xact))))
 
 (defun ledger-post-edit-amount ()
-  "Call `calc' and push the amount in the posting to the top of stack, if any."
+  "Call `calc' and push the amount in the posting to the top of stack, if any.
+
+In the calc buffer, press y to use the top value in the stack as
+the amount and return to ledger."
   (interactive)
   (beginning-of-line)
   (when (re-search-forward ledger-post-line-regexp (line-end-position) t)

--- a/ledger-post.el
+++ b/ledger-post.el
@@ -181,14 +181,7 @@ regular text."
           (end-of-line)
         (insert "  "))
       (push-mark (point) 'nomsg)
-      (calc))
-
-    ;; Preserve calc's own welcome message, if any, and append our own.
-    (message "%s%s"
-             (if-let (msg (current-message))
-                 (concat msg "\n\n")
-               "")
-             (substitute-command-keys "Press \\[universal-argument] \\[calc-copy-to-buffer] to use the top of stack as the new amount."))))
+      (calc))))
 
 (provide 'ledger-post)
 


### PR DESCRIPTION
Unfortunately, a4115ddfed6440897c18137ded5b6b2d14491c44 had a bad side effect
where, because the calc welcome message was multiple lines, calc-window-height
could be calculated incorrectly, and would be decreased each time calc was
called, eventually leading to it possibly having a negative value.

Instead of displaying a hint message, just put a message in the docstring of
`ledger-post-edit-amount`, which is not quite as nice but won't cause this bug.