### PR TITLE
Add user option for completion collection for payees

### DIFF
--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -47,6 +47,15 @@ element of `ledger-accounts-list-in-buffer'."
   :group 'ledger
   :package-version '(ledger-mode . "2019-08-14"))
 
+(defcustom ledger-payees-collection #'ledger-payees-in-buffer
+  "Collection of payees to be used for completion.
+This option may be set to any kind of collection accepted by
+`completing-read', which see."
+  :type '(choice (const :tag "Payees in current buffer" ledger-payees-in-buffer)
+                 (sexp :tag "Other"))
+  :group 'ledger
+  :package-version '(ledger-mode . "4.0.0"))
+
 (defcustom ledger-complete-in-steps nil
   "When non-nil, `ledger-complete-at-point' completes account names in steps.
 If nil, full account names are offered for completion."
@@ -297,7 +306,7 @@ Looks in `ledger-accounts-file' if set, otherwise the current buffer."
           (;; Payees
            (eq (save-excursion (ledger-thing-at-point)) 'transaction)
            (setq start (save-excursion (backward-word) (point)))
-           (setq collection #'ledger-payees-in-buffer))
+           (setq collection ledger-payees-collection))
           (;; Accounts
            (save-excursion
              (back-to-indentation)


### PR DESCRIPTION
This user option can be used to offer completion over a list of payees from a file:

``` elisp
(defvar-local my/ledger-payees-collection nil
  ;; TODO: If `project.el' adds support for project-local variables,
  ;; use that instead of `defvar-local'.
  "Memoized payees collection returned by `my/ledger-payees-collection'.")

(defun my/ledger-payees-collection ()
  "Return memoized list of payees contained in `my/payees-file'.
`my/payees-file' can be locally bound to a filepath string to a
file containing a newline-delimited list of payees, where the
filepath is relative to the current project root.  With nil or
nonexistent `my/payees-file', return `ledger-payees-in-buffer.'"
  (let ((payees-file
         (and (bound-and-true-p my/payees-file)
              (expand-file-name my/payees-file (project-root (project-current t))))))
    (cond ((not (and payees-file (file-exists-p payees-file)))
           #'ledger-payees-in-buffer)
          ((or (not my/ledger-payees-collection)
               (file-has-changed-p payees-file
                                   'my/ledger-payees-collection))
           (setf my/ledger-payees-collection
                 (with-current-buffer (find-file-noselect payees-file)
                   (split-string (buffer-string) "\n"))))
          (my/ledger-payees-collection))))

(setopt ledger-payees-collection #'my/ledger-payees-collection)
```

  To use this snippet, create a file containing a list of payees inside your project and set its relative filepath as a dir-local variable:

``` elisp
((ledger-mode . ((my/payees-file . "export/all-payees.txt"))))
```