### PR TITLE
Fix ledger auto report width

### DIFF
--- a/ledger-report.el
+++ b/ledger-report.el
@@ -457,7 +457,7 @@ MONTH is of the form (YEAR . INDEX) where INDEX ranges from
   `(,@(when (ledger-report--cmd-needs-links-p report-cmd)
         '("--prepend-format=%(filename):%(beg_line):"))
     ,@(when ledger-report-auto-width
-        `("--columns" ,(format "%d" (- (window-width) 1))))
+        `("--columns" ,(format "%d" (window-max-chars-per-line))))
     ,@(when ledger-report-use-native-highlighting
         ledger-report-native-highlighting-arguments)
     ,@(when ledger-report-use-strict


### PR DESCRIPTION
By using the `window-max-chars-per-line` instead of `window-width`, which seems exactly what we want here according to the doc:

Return the number of characters that can be displayed on one line.

This function automatically take care of the glyph column.