### PR TITLE
Allow `ledger-insert-effective-date` to work with regions.

### DIFF
--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -176,34 +176,75 @@ the balance into that."
                       nil 'noerr)
                  (replace-match ""))))))))
 
-(defun ledger-insert-effective-date (&optional date)
+(defun ledger-insert-effective-date (&optional start end date)
   "Insert effective date `DATE' to the transaction or posting.
 
-If `DATE' is nil, prompt the user a date.
+If `DATE' is nil, prompt the user for a date.
 
 Replace the current effective date if there's one in the same
 line.
 
-With a prefix argument, remove the effective date."
-  (interactive)
-  (if (and (listp current-prefix-arg)
-           (= 4 (prefix-numeric-value current-prefix-arg)))
-      (ledger-remove-effective-date)
-    (let* ((context (car (ledger-context-at-point)))
-           (date-string (or date (ledger-read-date "Effective date: "))))
-      (save-restriction
-        (narrow-to-region (line-beginning-position) (line-end-position))
-        (cond
-         ((eq 'xact context)
-          (beginning-of-line)
-          (re-search-forward ledger-iso-date-regexp)
-          (when (= (char-after) ?=)
-            (ledger-remove-effective-date))
-          (insert "=" date-string))
-         ((eq 'acct-transaction context)
-          (end-of-line)
-          (ledger-remove-effective-date)
-          (insert "  ; [=" date-string "]")))))))
+With a prefix argument, remove the effective date.
+
+With an active region (`START' and `END' non-nil), insert or
+remove for all transactions starting within the region."
+  (interactive
+   (if (use-region-p)
+       (list (region-beginning) (region-end))
+     (list nil nil)))
+
+  (if (and start end) (ledger-insert-effective-date-region start end date)
+    (if (and (listp current-prefix-arg)
+             (= 4 (prefix-numeric-value current-prefix-arg)))
+        (ledger-remove-effective-date)
+      (let* ((context (car (ledger-context-at-point)))
+             (date-string (or date (ledger-read-date "Effective date: "))))
+        (save-restriction
+          (narrow-to-region (line-beginning-position) (line-end-position))
+          (cond
+           ((eq 'xact context)
+            (beginning-of-line)
+            (re-search-forward ledger-iso-date-regexp)
+            (when (= (char-after) ?=)
+              (ledger-remove-effective-date))
+            (insert "=" date-string))
+           ((eq 'acct-transaction context)
+            (end-of-line)
+            (ledger-remove-effective-date)
+            (insert "  ; [=" date-string "]"))))))))
+
+(defun ledger-insert-effective-date-region (start end &optional date)
+  "Insert effective date `DATE' to all transactions starting within
+the region.
+
+If `DATE' is nil, prompt the user for a date.
+
+Replace the current effective date if there is one.
+
+With a prefix argument, remove any effective dates."
+  (interactive "r")
+  (let* ((should-remove
+          (and (listp current-prefix-arg)
+               (= 4 (prefix-numeric-value current-prefix-arg))))
+         (date-string
+          (unless should-remove
+            (or date (ledger-read-date "Effective date: ")))))
+    (save-excursion
+      (setq end (copy-marker end))
+      (goto-char start)
+      (while (< (point) end)
+        (let ((context (car (ledger-context-at-point))))
+          (save-restriction
+            (narrow-to-region (line-beginning-position) (line-end-position))
+            (when (eq 'xact context)
+              (if should-remove
+                  (ledger-remove-effective-date)
+                (beginning-of-line)
+                (re-search-forward ledger-iso-date-regexp)
+                (when (= (char-after) ?=)
+                  (ledger-remove-effective-date))
+                (insert "=" date-string)))))
+        (forward-line 1)))))
 
 (defun ledger-mode-remove-extra-lines ()
   "Get rid of multiple empty lines."

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -36,7 +36,8 @@
 (require 'ledger-exec)
 (require 'ledger-navigate)
 (require 'ledger-state)
-(declare-function ledger-insert-effective-date "ledger-mode" (&optional date))
+(declare-function ledger-insert-effective-date "ledger-mode"
+                  (&optional start end date))
 (declare-function ledger-read-account-with-prompt "ledger-mode" (prompt))
 (declare-function ledger-read-date "ledger-mode" (prompt))
 


### PR DESCRIPTION
It updates or removes the effective date of all transactions that start in the region (technically, that start on a line in the region), without editing any postings.

With my credit card, I use the statement date as the effective date. That means I have a long block of transactions that all have the same effective date. This makes it easy to set them all at once.