### PR TITLE
Refactor definitions and use of buffer-local variables

### DIFF
--- a/ledger-check.el
+++ b/ledger-check.el
@@ -32,7 +32,7 @@
 
 
 (defvar ledger-check-buffer-name "*Ledger Check*")
-(defvar ledger-original-window-cfg nil)
+(defvar-local ledger-check--original-window-configuration nil)
 
 
 
@@ -45,7 +45,7 @@
   "Keymap for `ledger-check-mode'.")
 
 (easy-menu-define ledger-check-mode-menu ledger-check-mode-map
-  "Ledger check menu"
+  "Ledger check menu."
   '("Check"
     ;; ["Re-run Check" ledger-check-redo]
     "---"
@@ -106,7 +106,7 @@
   "Quit the ledger check buffer."
   (interactive)
   (ledger-check-goto)
-  (set-window-configuration ledger-original-window-cfg)
+  (set-window-configuration ledger-check--original-window-configuration)
   (kill-buffer (get-buffer ledger-check-buffer-name)))
 
 (defun ledger-check-buffer ()
@@ -130,7 +130,7 @@ commands for navigating the buffer to the errors found, etc."
     (with-current-buffer
         (pop-to-buffer (get-buffer-create ledger-check-buffer-name))
       (ledger-check-mode)
-      (set (make-local-variable 'ledger-original-window-cfg) wcfg)
+      (setq ledger-check--original-window-configuration wcfg)
       (ledger-do-check)
       (shrink-window-if-larger-than-buffer)
       (set-buffer-modified-p nil)

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -548,7 +548,10 @@ moved and recentered.  If they aren't strange things happen."
         (search-forward account nil t))))
 
 (defun ledger-reconcile (&optional account target)
-  "Start reconciling, prompt for ACCOUNT."
+  "Start reconciling, prompt for ACCOUNT.
+
+If TARGET is non-nil, it is used as the initial target for
+reconciliation, otherwise prompt for TARGET."
   (interactive)
   (let ((account (or account (ledger-read-account-with-prompt "Account to reconcile")))
         (buf (current-buffer))

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -41,7 +41,6 @@
 (declare-function ledger-read-date "ledger-mode" (prompt))
 
 (defvar ledger-buf nil)
-(defvar ledger-bufs nil)
 (defvar ledger-acct nil)
 (defvar ledger-target nil)
 
@@ -353,9 +352,8 @@ When called interactively, prompt for DATE, then XACT."
   "Save the ledger buffer."
   (interactive)
   (with-selected-window (selected-window) ; restoring window is needed because after-save-hook will modify window and buffers
-    (dolist (buf (cons ledger-buf ledger-bufs))
-      (with-current-buffer buf
-        (basic-save-buffer)))))
+    (with-current-buffer ledger-buf
+      (basic-save-buffer))))
 
 
 (defun ledger-reconcile-finish ()

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -40,9 +40,14 @@
 (declare-function ledger-read-account-with-prompt "ledger-mode" (prompt))
 (declare-function ledger-read-date "ledger-mode" (prompt))
 
-(defvar ledger-buf nil)
-(defvar ledger-acct nil)
-(defvar ledger-target nil)
+(defvar-local ledger-reconcile-ledger-buf nil
+  "Buffer from which the current reconcile buffer was created.")
+
+(defvar-local ledger-reconcile-account nil
+  "Account being reconciled in the current buffer.")
+
+(defvar-local ledger-reconcile-target nil
+  "Target amount for this reconciliation process.")
 
 (defgroup ledger-reconcile nil
   "Options for Ledger-mode reconciliation"
@@ -201,12 +206,12 @@ described above."
   "Display the cleared-or-pending balance.
 And calculate the target-delta of the account being reconciled."
   (interactive)
-  (let* ((pending (ledger-reconcile-get-cleared-or-pending-balance ledger-buf ledger-acct)))
+  (let* ((pending (ledger-reconcile-get-cleared-or-pending-balance ledger-reconcile-ledger-buf ledger-reconcile-account)))
     (when pending
-      (if ledger-target
+      (if ledger-reconcile-target
           (message "Cleared and Pending balance: %s,   Difference from target: %s"
                    (ledger-commodity-to-string pending)
-                   (ledger-commodity-to-string (ledger-subtract-commodity ledger-target pending)))
+                   (ledger-commodity-to-string (ledger-subtract-commodity ledger-reconcile-target pending)))
         (message "Pending balance: %s"
                  (ledger-commodity-to-string pending))))))
 
@@ -308,7 +313,7 @@ When called interactively, prompt for DATE, then XACT."
   (interactive
    (list (ledger-read-date "Date: ")
          (read-string "Transaction: " nil 'ledger-minibuffer-history)))
-  (with-current-buffer ledger-buf
+  (with-current-buffer ledger-reconcile-ledger-buf
     (ledger-add-transaction (concat date " " xact)))
   (ledger-reconcile-refresh))
 
@@ -352,7 +357,7 @@ When called interactively, prompt for DATE, then XACT."
   "Save the ledger buffer."
   (interactive)
   (with-selected-window (selected-window) ; restoring window is needed because after-save-hook will modify window and buffers
-    (with-current-buffer ledger-buf
+    (with-current-buffer ledger-reconcile-ledger-buf
       (basic-save-buffer))))
 
 
@@ -384,7 +389,7 @@ exit reconcile mode if `ledger-reconcile-finish-force-quit'"
     (if reconcile-buf
         (with-current-buffer reconcile-buf
           (ledger-reconcile-quit-cleanup)
-          (setq buf ledger-buf)
+          (setq buf ledger-reconcile-ledger-buf)
           ;; Make sure you delete the window before you delete the buffer,
           ;; otherwise, madness ensues
           (delete-window (get-buffer-window reconcile-buf))
@@ -394,7 +399,7 @@ exit reconcile mode if `ledger-reconcile-finish-force-quit'"
 (defun ledger-reconcile-quit-cleanup ()
   "Cleanup all hooks established by reconcile mode."
   (interactive)
-  (let ((buf ledger-buf))
+  (let ((buf ledger-reconcile-ledger-buf))
     (if (buffer-live-p buf)
         (with-current-buffer buf
           (remove-hook 'after-save-hook 'ledger-reconcile-refresh-after-save t)
@@ -403,10 +408,10 @@ exit reconcile mode if `ledger-reconcile-finish-force-quit'"
             (ledger-highlight-xact-under-point))))))
 
 (defun ledger-marker-where-xact-is (emacs-xact posting)
-  "Find the position of the EMACS-XACT in the `ledger-buf'.
+  "Find the position of the EMACS-XACT in the `ledger-reconcile-ledger-buf'.
 POSTING is used in `ledger-clear-whole-transactions' is nil."
   (let ((buf (if (ledger-is-stdin (nth 0 emacs-xact))
-                 ledger-buf
+                 ledger-reconcile-ledger-buf
                (find-file-noselect (nth 0 emacs-xact)))))
     (cons
      buf
@@ -472,8 +477,8 @@ POSTING is used in `ledger-clear-whole-transactions' is nil."
   "SORT the uncleared transactions in the account.
 The sorted results are displayed in in the *Reconcile* buffer.
 Return a count of the uncleared transactions."
-  (let* ((buf ledger-buf)
-         (account ledger-acct)
+  (let* ((buf ledger-reconcile-ledger-buf)
+         (account ledger-reconcile-account)
          (sort-by (if sort
                       sort
                     "(date)"))
@@ -509,14 +514,14 @@ moved and recentered.  If they aren't strange things happen."
   (let ((reconcile-window (get-buffer-window (get-buffer ledger-reconcile-buffer-name))))
     (when reconcile-window
       (fit-window-to-buffer reconcile-window)
-      (with-current-buffer ledger-buf
+      (with-current-buffer ledger-reconcile-ledger-buf
         (add-hook 'kill-buffer-hook 'ledger-reconcile-quit nil t)
-        (if (get-buffer-window ledger-buf)
-            (select-window (get-buffer-window ledger-buf)))
+        (if (get-buffer-window ledger-reconcile-ledger-buf)
+            (select-window (get-buffer-window ledger-reconcile-ledger-buf)))
         (recenter))
       (select-window reconcile-window)
       (ledger-reconcile-visit t))
-    (with-current-buffer ledger-buf
+    (with-current-buffer ledger-reconcile-ledger-buf
       (when ledger-occur-mode
         (ledger-occur-refresh)))
     (add-hook 'post-command-hook 'ledger-reconcile-track-xact nil t)))
@@ -560,11 +565,11 @@ reconciliation, otherwise prompt for TARGET."
     (when (ledger-reconcile-check-valid-account account)
       (if rbuf ;; *Reconcile* already exists
           (with-current-buffer rbuf
-            (set 'ledger-acct account) ;; already buffer local
+            (setq ledger-reconcile-account account)
             (when (not (eq buf rbuf))
               ;; called from some other ledger-mode buffer
               (ledger-reconcile-quit-cleanup)
-              (setq ledger-buf buf)) ;; should already be buffer-local
+              (setq ledger-reconcile-ledger-buf buf))
 
             (unless (get-buffer-window rbuf)
               (ledger-reconcile-open-windows buf rbuf)))
@@ -575,9 +580,8 @@ reconciliation, otherwise prompt for TARGET."
                                    (get-buffer-create ledger-reconcile-buffer-name))
           (ledger-reconcile-open-windows buf rbuf)
           (ledger-reconcile-mode)
-          (make-local-variable 'ledger-target)
-          (set (make-local-variable 'ledger-buf) buf)
-          (set (make-local-variable 'ledger-acct) account)))
+          (setq ledger-reconcile-ledger-buf buf)
+          (setq ledger-reconcile-account account)))
 
       (add-hook 'after-save-hook 'ledger-reconcile-refresh-after-save nil t)
 
@@ -595,7 +599,7 @@ reconciliation, otherwise prompt for TARGET."
 (defun ledger-reconcile-change-target (&optional target)
   "Change the TARGET amount for the reconciliation process."
   (interactive)
-  (setq ledger-target (or target (ledger-read-commodity-string ledger-reconcile-target-prompt-string)))
+  (setq ledger-reconcile-target (or target (ledger-read-commodity-string ledger-reconcile-target-prompt-string)))
   (ledger-display-balance))
 
 (defmacro ledger-reconcile-change-sort-key-and-refresh (sort-by)

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -39,7 +39,7 @@
   (require 'subr-x))
 
 (defgroup ledger-report nil
-  "Customization option for the Report buffer"
+  "Customization option for the Report buffer."
   :group 'ledger)
 
 (defcustom ledger-reports
@@ -208,7 +208,7 @@ See documentation for the function `ledger-master-file'")
   "Keymap for `ledger-report-mode'.")
 
 (easy-menu-define ledger-report-mode-menu ledger-report-mode-map
-  "Ledger report menu"
+  "Ledger report menu."
   '("Reports"
     ["Select Report" ledger-report]
     ["Save Report" ledger-report-save]

--- a/test/reconcile-test.el
+++ b/test/reconcile-test.el
@@ -758,7 +758,7 @@ https://github.com/ledger/ledger-mode/issues/383"
         demo-ledger
       (ledger-reconcile "Expenses:Books" '(0 "$"))
       (switch-to-buffer ledger-reconcile-buffer-name)
-      (with-current-buffer ledger-buf
+      (with-current-buffer ledger-reconcile-ledger-buf
         (should (equal (ledger-test-visible-buffer-string) "
 2011/01/27 Book Store
   Expenses:Books                       $20.00
@@ -774,7 +774,7 @@ https://github.com/ledger/ledger-mode/issues/383"
       (setq ledger-default-date-format "%Y/%m/%d")
       ;; buffer overlays should be refreshed after adding xact
       (ledger-reconcile-add "2011/06/15" "Bookstore")
-      (with-current-buffer ledger-buf
+      (with-current-buffer ledger-reconcile-ledger-buf
         (should (equal (ledger-test-visible-buffer-string) "
 2011/01/27 Book Store
   Expenses:Books                       $20.00


### PR DESCRIPTION
This PR cleans up some use of buffer-local variables in ledger checks, reports,
and reconcile buffers.  These variables are now properly namespaced and
designated as permanent buffer-locals, so they can be set straightforwardly with
setq.

I added docstrings only for the ledger-reconcile buffer-locals, because at least
one of them is used in a test.

While I consider this code mostly pretty straightforward, it does have the
potential to break somebody's personal config if they are referring to any of
these variables by the (un-namespaced) original name.  @purcell, thoughts?