### PR TITLE
Fix #54 and refactor ledger-occur overlay logic

### DIFF
--- a/ledger-occur.el
+++ b/ledger-occur.el
@@ -155,7 +155,9 @@ Argument OVL-BOUNDS contains bounds for the transactions to be left visible."
       (nreverse lines))))
 
 (defun ledger-occur-compress-matches (buffer-matches)
-  "identify sequential xacts to reduce number of overlays required"
+  "Identify sequential xacts to reduce number of overlays required.
+
+BUFFER-MATCHES should be a list of (BEG END) lists."
   (if buffer-matches
       (let ((points (list))
             (current-beginning (caar buffer-matches))

--- a/ledger-occur.el
+++ b/ledger-occur.el
@@ -128,6 +128,7 @@ Argument OVL-BOUNDS contains bounds for the transactions to be left visible."
       (ledger-occur-make-invisible-overlay (1+ end) (1- (car visible)))
       (setq beg (car visible))
       (setq end (cadr visible)))
+    (ledger-occur-make-visible-overlay beg end)
     (ledger-occur-make-invisible-overlay (1+ end) (point-max))))
 
 (defun ledger-occur-remove-overlays ()

--- a/ledger-occur.el
+++ b/ledger-occur.el
@@ -92,8 +92,8 @@ currently active."
 (defun ledger-occur-prompt ()
   "Return the default value of the prompt.
 
-   Default value for prompt is a current word or active
-   region(selection), if its size is 1 line"
+Default value for prompt is the active region, if it is one line
+long, otherwise it is the word at point."
   (if (use-region-p)
       (let ((pos1 (region-beginning))
             (pos2 (region-end)))

--- a/test/occur-test.el
+++ b/test/occur-test.el
@@ -93,6 +93,54 @@ https://github.com/ledger/ledger-mode/issues/54"
                 'ledger-occur-xact-face))))
 
 
+(ert-deftest ledger-occur/test-003 ()
+  "Additional tests for various edge cases."
+  :tags '(occur regress)
+
+  (ledger-tests-with-temp-file
+      "\
+2024-03-12 Grocery Store
+  Expenses:Food:Groceries     $50
+  Assets:Checking
+
+2024-03-15 Employer
+  * Assets:Checking           $2000.00
+  Income:Salary
+
+2024-03-19 Grocery Store
+  Expenses:Food:Groceries     $50
+  Assets:Checking
+"
+    ;; invisible on both sides of a visible portion
+    (ledger-occur "Employer")
+    (should
+     (equal (ledger-test-visible-buffer-string)
+            "\
+
+2024-03-15 Employer
+  * Assets:Checking           $2000.00
+  Income:Salary
+"))
+
+    ;; no matches
+    (ledger-occur "zzzzzz")
+    (should
+     (equal (ledger-test-visible-buffer-string)
+            "\
+2024-03-12 Grocery Store
+  Expenses:Food:Groceries     $50
+  Assets:Checking
+
+2024-03-15 Employer
+  * Assets:Checking           $2000.00
+  Income:Salary
+
+2024-03-19 Grocery Store
+  Expenses:Food:Groceries     $50
+  Assets:Checking
+"))))
+
+
 (provide 'occur-test)
 
 ;;; occur-test.el ends here

--- a/test/occur-test.el
+++ b/test/occur-test.el
@@ -35,7 +35,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=246"
   :tags '(occur regress)
 
   (ledger-tests-with-temp-file
-   "2011/01/02 Grocery Store
+      "2011/01/02 Grocery Store
   Expenses:Food:Groceries             $ 65.00
   * Assets:Checking
 
@@ -43,13 +43,54 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=246"
   * Assets:Checking                 $ 2000.00
   Income:Salary
 "
-   (ledger-occur "Groceries")
-   (should
-    (equal (ledger-test-visible-buffer-string)
-           "2011/01/02 Grocery Store
+    (ledger-occur "Groceries")
+    (should
+     (equal (ledger-test-visible-buffer-string)
+            "2011/01/02 Grocery Store
   Expenses:Food:Groceries             $ 65.00
   * Assets:Checking
 "))))
+
+(ert-deftest ledger-occur/test-002 ()
+  "Regression test for #54.
+https://github.com/ledger/ledger-mode/issues/54"
+  :tags '(occur regress)
+
+  (ledger-tests-with-temp-file
+      "\
+2024-03-12 Grocery Store
+  Expenses:Food:Groceries     $50
+  Assets:Checking
+
+2024-03-15 Employer
+  * Assets:Checking           $2000.00
+  Income:Salary
+
+2024-03-19 Grocery Store
+  Expenses:Food:Groceries     $50
+  Assets:Checking
+"
+    (ledger-occur "Groceries")
+    (should
+     (equal (ledger-test-visible-buffer-string)
+            "\
+2024-03-12 Grocery Store
+  Expenses:Food:Groceries     $50
+  Assets:Checking
+
+2024-03-19 Grocery Store
+  Expenses:Food:Groceries     $50
+  Assets:Checking
+"))
+
+    (setq ledger-occur-use-face-shown t)
+    (goto-char (point-min))
+    (search-forward "2024-03-12")
+    (should (eq (get-char-property (point) 'font-lock-face)
+                'ledger-occur-xact-face))
+    (search-forward "2024-03-19")
+    (should (eq (get-char-property (point) 'font-lock-face)
+                'ledger-occur-xact-face))))
 
 
 (provide 'occur-test)


### PR DESCRIPTION
Fix #54.

This PR adds some regression tests for ledger-occur, as well as refactoring the
overlay creation loop to be a bit easier to understand.

Another option I considered was to use a single overlay for the whole buffer to
make most of it invisible, and then only create overlays to make the match areas
visible.  However, with ledger-occur-xact-face, it highlights the newlines in
between the xacts, which is a little weird, so I didn't end up making this
change.