### PR TITLE
Use correct regexp when scanning for account names

### DIFF
--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -153,7 +153,7 @@ Then one of the elements this function returns will be
          (lambda (_pos _date _state _payee)
            (let ((end (save-excursion (ledger-navigate-end-of-xact))))
              (forward-line)
-             (while (re-search-forward ledger-account-name-or-directive-regex end t)
+             (while (re-search-forward ledger-account-any-status-regex end t)
                (let ((account (match-string-no-properties 1)))
                  (unless (gethash account seen)
                    (puthash account t seen)


### PR DESCRIPTION
This is a minor fix to a previous change from @bcc32 — would you mind checking it over please?

The previous loop searched for directives, and the intention of this second loop is to search only for account names used in transactions, so we don't need to use the combined regexp here after all.