### PR TITLE
ledger-toggle-current: Do not toggle if not in a transaction

### DIFF
--- a/ledger-context.el
+++ b/ledger-context.el
@@ -109,8 +109,9 @@ where the \"users\" point was."
     (list line-type field fields)))
 
 (defun ledger-thing-at-point ()
-  "Describe thing at points.  Return \='transaction, \='posting, or nil.
-Leave point at the beginning of the thing under point"
+  "Describe thing at point.  Return \='transaction, \='posting, \='day, or nil.
+
+Leave point at the beginning of the thing at point, otherwise do not move point."
   (let ((here (point)))
     (goto-char (line-beginning-position))
     (cond ((looking-at "^\\(?:[~=][ \t]\\|[0-9/.=-]+\\(\\s-+\\*\\)?\\(\\s-+(.+?)\\)?\\s-+\\)")

--- a/ledger-state.el
+++ b/ledger-state.el
@@ -215,20 +215,21 @@ dropped."
 (defun ledger-toggle-current (&optional style)
   "Toggle the current thing at point with optional STYLE."
   (interactive)
-  (if (or ledger-clear-whole-transactions
-          (eq 'transaction (ledger-thing-at-point)))
-      (let ((end (save-excursion (ledger-navigate-end-of-xact) (point-marker))))
-        ;; clear state markings on postings
-        (save-excursion
-          (forward-line)
-          (beginning-of-line)
-          (while (< (point) end)
-            (when (looking-at "\\s-+[*!]")
-              (ledger-toggle-current-posting style))
-            (forward-line)))
-        (set-marker end nil)
-        (ledger-toggle-current-transaction style))
-    (ledger-toggle-current-posting style)))
+  (let ((thing (ledger-thing-at-point)))
+    (if (or (and ledger-clear-whole-transactions (eq 'posting thing))
+            (eq 'transaction thing))
+        (let ((end (save-excursion (ledger-navigate-end-of-xact) (point-marker))))
+          ;; clear state markings on postings
+          (save-excursion
+            (forward-line)
+            (beginning-of-line)
+            (while (< (point) end)
+              (when (looking-at "\\s-+[*!]")
+                (ledger-toggle-current-posting style))
+              (forward-line)))
+          (set-marker end nil)
+          (ledger-toggle-current-transaction style))
+      (ledger-toggle-current-posting style))))
 
 (defun ledger-toggle-current-transaction (&optional style)
   "Toggle the transaction at point using optional STYLE."

--- a/test/state-test.el
+++ b/test/state-test.el
@@ -135,6 +135,32 @@ https://github.com/ledger/ledger-mode/issues/274"
   Expenses:Food:Groceries             $ 44.00 ; hastag: not block
   Assets:Checking"))))
 
+
+(ert-deftest ledger-state/test-004 ()
+  "Regression test for #374
+https://github.com/ledger/ledger-mode/issues/374"
+
+  (ledger-tests-with-temp-file
+      "2024/01/01 Test
+    Expenses                                   $4.00
+    Assets
+
+;; Some comments.
+;; Try hitting `ledger-toggle-current' from this line
+"
+    (setq ledger-clear-whole-transactions t)
+    (goto-char (1- (point-max)))
+    (ledger-toggle-current)
+    (should
+     (equal (buffer-string)
+            "2024/01/01 Test
+    Expenses                                   $4.00
+    Assets
+
+;; Some comments.
+;; Try hitting `ledger-toggle-current' from this line
+"))))
+
 (provide 'state-test)
 
 ;;; state-test.el ends here


### PR DESCRIPTION
`ledger-navigate-end-of-xact` does not work correctly if point is not in a
transaction.  We can simply explicitly check whether `ledger-thing-at-point`
returned a posting instead.

Fix #374