### PR TITLE
Fix #416 by allowing subtraction of zero-amount mismatched commodities

### DIFF
--- a/ledger-commodities.el
+++ b/ledger-commodities.el
@@ -94,16 +94,26 @@ Returns a list with (value commodity)."
           (split-string str "[\n\r]")))
 
 (defun ledger-subtract-commodity (c1 c2)
-  "Subtract C2 from C1, ensuring their commodities match."
-  (if (string= (cadr c1) (cadr c2))
-      (list (-(car c1) (car c2)) (cadr c1))
-    (error "Can't subtract different commodities %S from %S" c2 c1)))
+  "Subtract C2 from C1, ensuring their commodities match.
+
+As an exception, if the quantity of C2 is zero, C1 is returned
+directly."
+  (cond
+   ((zerop (car c2)) c1)
+   ((string= (cadr c1) (cadr c2))
+    (list (- (car c1) (car c2)) (cadr c1)))
+   (t (error "Can't subtract different commodities %S from %S" c2 c1))))
 
 (defun ledger-add-commodity (c1 c2)
-  "Add C1 and C2, ensuring their commodities match."
-  (if (string= (cadr c1) (cadr c2))
-      (list (+ (car c1) (car c2)) (cadr c1))
-    (error "Can't add different commodities, %S to %S" c1 c2)))
+  "Add C1 and C2, ensuring their commodities match.
+
+As an exception, if the quantity of C2 is zero, C1 is returned
+directly."
+  (cond
+   ((zerop (car c2)) c1)
+   ((string= (cadr c1) (cadr c2))
+    (list (+ (car c1) (car c2)) (cadr c1)))
+   (t (error "Can't add different commodities, %S to %S" c1 c2))))
 
 (defun ledger-strip (str char)
   "Return STR with CHAR removed."

--- a/ledger-commodities.el
+++ b/ledger-commodities.el
@@ -102,7 +102,7 @@ directly."
    ((zerop (car c2)) c1)
    ((string= (cadr c1) (cadr c2))
     (list (- (car c1) (car c2)) (cadr c1)))
-   (t (error "Can't subtract different commodities %S from %S" c2 c1))))
+   (t (error "Can't subtract different commodities: %S - %S" c1 c2))))
 
 (defun ledger-add-commodity (c1 c2)
   "Add C1 and C2, ensuring their commodities match.
@@ -113,7 +113,7 @@ directly."
    ((zerop (car c2)) c1)
    ((string= (cadr c1) (cadr c2))
     (list (+ (car c1) (car c2)) (cadr c1)))
-   (t (error "Can't add different commodities, %S to %S" c1 c2))))
+   (t (error "Can't add different commodities: %S + %S" c1 c2))))
 
 (defun ledger-strip (str char)
   "Return STR with CHAR removed."

--- a/test/reconcile-test.el
+++ b/test/reconcile-test.el
@@ -790,6 +790,28 @@ https://github.com/ledger/ledger-mode/issues/383"
 "))))))
 
 
+(ert-deftest ledger-reconcile/test-031 ()
+  "Regression test for #416
+https://github.com/ledger/ledger-mode/issues/416"
+
+  (ledger-tests-with-temp-file
+      "\
+2011/01/27 * Book Store
+  Expenses:Books                       $20.00
+  Liabilities:MasterCard
+
+2011/02/15 * Bank
+  Liabilities:MasterCard               $20.00
+  Assets:Checking
+
+2011/02/27 Book Store
+  Expenses:Books                       $20.00
+  Liabilities:MasterCard
+"
+
+    (ledger-reconcile "Liabilities:MasterCard" (ledger-split-commodity-string "$20"))))
+
+
 (provide 'reconcile-test)
 
 ;;; reconcile-test.el ends here


### PR DESCRIPTION
This PR changes `ledger-{add,subtract}-commodity` to allow the second argument's
commodity string not to match the first argument's, as long as the second amount
is zero.  Since subtracting a zero amount is a no-op anyway, this should be fine
in terms of correctness, and alleviates some spurious errors.

Fix #416