### PR TITLE
Add command ledger-rename-account

### DIFF
--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -235,6 +235,32 @@ With a prefix argument, remove the effective date."
       (beginning-of-line)
       (forward-char distance-in-xact))))
 
+(defun ledger-rename-account (old new &optional toplevel-only)
+  "Rename account with name OLD to name NEW.
+
+Affects account names mentioned in postings as well as declared
+with the \"account\" directive.
+
+By default, child accounts of OLD are also renamed to
+corresponding child accounts of NEW.  With \\[universal-argument]
+prefix, child accounts are not renamed.  When called from Lisp,
+TOPLEVEL-ONLY has the same meaning."
+  (interactive "sOld name: \nsNew name: \nP")
+  (save-excursion
+    (goto-char (point-min))
+    (while (re-search-forward ledger-account-name-or-directive-regex nil t)
+      (let ((account (match-string 1)))
+        (cond
+         ((string-equal account old)
+          (replace-match new 'fixedcase 'literal nil 1))
+         ((and (not toplevel-only)
+               (string-prefix-p (concat old ":") account))
+          (replace-match
+           (concat new (substring account (length old)))
+           'fixedcase 'literal nil 1))))))
+  (when ledger-post-auto-align
+    (ledger-post-align-postings (point-min) (point-max))))
+
 (defvar ledger-mode-syntax-table
   (let ((table (make-syntax-table text-mode-syntax-table)))
     (modify-syntax-entry ?\; "<" table)

--- a/test/mode-test.el
+++ b/test/mode-test.el
@@ -75,6 +75,44 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=256"
     (comment-dwim nil)
     (should (string-match (rx buffer-start "#" (0+ whitespace)) (buffer-string)))))
 
+
+(ert-deftest ledger-mode/test-004 ()
+  "Baseline test for `ledger-rename-account'."
+  :tags '(mode baseline)
+  (ledger-tests-with-temp-file
+      "2024-04-01 Grocery Store
+    Expenses:Groceries                           $30
+    Expenses:Groceries:Snacks                    $10
+    Assets:Cash
+"
+    (save-buffer)
+
+    (ledger-rename-account
+     "Expenses:Groceries"
+     "Expenses:Grocery")
+
+    (should
+     (equal (buffer-string)
+            "2024-04-01 Grocery Store
+    Expenses:Grocery                             $30
+    Expenses:Grocery:Snacks                      $10
+    Assets:Cash
+"))
+
+    (revert-buffer t t)
+    (ledger-rename-account
+     "Expenses:Groceries"
+     "Expenses:Grocery"
+     'toplevel-only)
+
+    (should
+     (equal (buffer-string)
+            "2024-04-01 Grocery Store
+    Expenses:Grocery                             $30
+    Expenses:Groceries:Snacks                    $10
+    Assets:Cash
+"))))
+
 (provide 'mode-test)
 
 ;;; mode-test.el ends here


### PR DESCRIPTION
This command should reliably renames an account (and its child accounts) only
in postings and account declarations, so it is a more precise alternative to
query-replace.

Close #154.