### PR TITLE
Fix some bugs in ledger-complete-at-point date completion

### DIFF
--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -283,15 +283,19 @@ an alist (ACCOUNT-ELEMENT . NODE)."
         realign-after
         delete-suffix)
     (cond (;; Date
-           (looking-back (concat "^" ledger-incomplete-date-regexp) (line-beginning-position))
+           (save-excursion
+             (skip-chars-forward "0-9/-")
+             (looking-back (concat "^" ledger-incomplete-date-regexp) (line-beginning-position)))
            (setq collection (ledger-complete-date (match-string 1) (match-string 2))
                  start (match-beginning 0)
                  delete-suffix (save-match-data
                                  (when (looking-at (rx (one-or-more (or digit (any ?/ ?-)))))
                                    (length (match-string 0))))))
           (;; Effective dates
-           (looking-back (concat "^" ledger-iso-date-regexp "=" ledger-incomplete-date-regexp)
-                         (line-beginning-position))
+           (save-excursion
+             (skip-chars-forward "0-9/-")
+             (looking-back (concat "^" ledger-iso-date-regexp "=" ledger-incomplete-date-regexp)
+                           (line-beginning-position)))
            (setq start (line-beginning-position))
            (setq collection (ledger-complete-effective-date
                              (match-string 2) (match-string 3) (match-string 4)

--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -221,51 +221,50 @@ an alist (ACCOUNT-ELEMENT . NODE)."
                   (cdr root))
           'string-lessp))))
 
+(defvar ledger-complete--current-time-for-testing nil
+  "Internal, used for testing only.")
+
 (defun ledger-complete-date (month-string day-string)
   "Complete a date."
-  (let*
-      ((now (current-time))
-       (decoded (decode-time now))
-       (this-month (nth 4 decoded))
-       (this-year (nth 5 decoded))
-       (last-month (if (> this-month 1) (1- this-month) 12))
-       (last-year (1- this-year))
-       (last-month-year (if (> this-month 1) this-year last-year))
-       (month (and month-string
-                   (string-to-number month-string)))
-       (day (string-to-number day-string))
-       (dates (list (encode-time 0 0 0 day (or month this-month) this-year)
-                    (if month
-                        (encode-time 0 0 0 day month last-year)
-                      (encode-time 0 0 0 day last-month last-month-year)))))
-    (lambda (_string _predicate _all)
-      (concat (ledger-format-date
-               (cl-find-if (lambda (date) (not (time-less-p now date))) dates))
-              (and (= (point) (line-end-position)) " ")))))
+  (let* ((now (or ledger-complete--current-time-for-testing (current-time)))
+         (decoded (decode-time now))
+         (this-month (nth 4 decoded))
+         (this-year (nth 5 decoded))
+         (last-month (if (> this-month 1) (1- this-month) 12))
+         (last-year (1- this-year))
+         (last-month-year (if (> this-month 1) this-year last-year))
+         (month (and month-string
+                     (string-to-number month-string)))
+         (day (string-to-number day-string))
+         (dates (list (encode-time 0 0 0 day (or month this-month) this-year)
+                      (if month
+                          (encode-time 0 0 0 day month last-year)
+                        (encode-time 0 0 0 day last-month last-month-year)))))
+    (list (concat (ledger-format-date
+                   (cl-find-if (lambda (date) (not (time-less-p now date))) dates))
+                  (and (= (point) (line-end-position)) " ")))))
 
 (defun ledger-complete-effective-date
     (tx-year-string tx-month-string tx-day-string
                     month-string day-string)
   "Complete an effective date."
-  (let*
-      ((tx-year (string-to-number tx-year-string))
-       (tx-month (string-to-number tx-month-string))
-       (tx-day (string-to-number tx-day-string))
-       (tx-date (encode-time 0 0 0 tx-day tx-month tx-year))
-       (next-month (if (< tx-month 12) (1+ tx-month) 1))
-       (next-year (1+ tx-year))
-       (next-month-year (if (< tx-month 12) tx-year next-year))
-       (month (and month-string
-                   (string-to-number month-string)))
-       (day (string-to-number day-string))
-       (dates (list (encode-time 0 0 0 day (or month tx-month) tx-year)
-                    (if month
-                        (encode-time 0 0 0 day month next-year)
-                      (encode-time 0 0 0 day next-month next-month-year)))))
-    (lambda (_string _predicate _all)
-      (concat (ledger-format-date
-               (cl-find-if (lambda (date) (not (time-less-p date tx-date))) dates))
-              (and (= (point) (line-end-position)) " ")))))
+  (let* ((tx-year (string-to-number tx-year-string))
+         (tx-month (string-to-number tx-month-string))
+         (tx-day (string-to-number tx-day-string))
+         (tx-date (encode-time 0 0 0 tx-day tx-month tx-year))
+         (next-month (if (< tx-month 12) (1+ tx-month) 1))
+         (next-year (1+ tx-year))
+         (next-month-year (if (< tx-month 12) tx-year next-year))
+         (month (and month-string
+                     (string-to-number month-string)))
+         (day (string-to-number day-string))
+         (dates (list (encode-time 0 0 0 day (or month tx-month) tx-year)
+                      (if month
+                          (encode-time 0 0 0 day month next-year)
+                        (encode-time 0 0 0 day next-month next-month-year)))))
+    (list (concat (ledger-format-date
+                   (cl-find-if (lambda (date) (not (time-less-p date tx-date))) dates))
+                  (and (= (point) (line-end-position)) " ")))))
 
 (defun ledger-complete-at-point ()
   "Do appropriate completion for the thing at point."

--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -417,9 +417,8 @@ https://github.com/ledger/ledger-mode/issues/419"
       ;; completion uses whole day number, not just the part before point
       (completion-at-point)
       (should
-       ;; TODO: Ideally, this should include a trailing space too.
        (equal (buffer-string)
-              "2023-12-23")))))
+              "2023-12-23 ")))))
 
 (provide 'complete-test)
 

--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -365,6 +365,56 @@ account Expenses:Groceries
                      '("Expenses:Food"
                        "Expenses:Groceries"))))))
 
+(defvar ledger-complete--current-time-for-testing)
+
+(ert-deftest ledger-complete/date-month-day ()
+  "Test completing an incomplete date with only a month and day.
+https://github.com/ledger/ledger-mode/issues/419"
+  :tags '(complete regress)
+  (let ((ledger-complete--current-time-for-testing ;2024-01-21
+         (encode-time 0 0 0 21 1 2024))
+        (ledger-default-date-format ledger-iso-date-format)
+        ;; TODO: Set up date completion so that it does not require a specific
+        ;; completion-style setting.
+        (completion-styles '(flex)))
+    (ledger-tests-with-temp-file
+        "01-19"
+      (goto-char (point-max))
+      (completion-at-point)
+      (should
+       (equal (buffer-string)
+              "2024-01-19 "))
+
+      (erase-buffer)
+      (insert "01-23")
+      (completion-at-point)
+      (should
+       (equal (buffer-string)
+              "2023-01-23 ")))))
+
+(ert-deftest ledger-complete/date-day-only ()
+  "Test completing an incomplete date with only a day.
+https://github.com/ledger/ledger-mode/issues/419"
+  :tags '(complete regress)
+  (let ((ledger-complete--current-time-for-testing ;2024-01-21
+         (encode-time 0 0 0 21 1 2024))
+        (ledger-default-date-format ledger-iso-date-format)
+        (completion-styles '(flex)))
+    (ledger-tests-with-temp-file
+        "19"
+      (goto-char (point-max))
+      (completion-at-point)
+      (should
+       (equal (buffer-string)
+              "2024-01-19 "))
+
+      (erase-buffer)
+      (insert "23")
+      (completion-at-point)
+      (should
+       (equal (buffer-string)
+              "2023-12-23 ")))))
+
 (provide 'complete-test)
 
 ;;; complete-test.el ends here

--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -409,7 +409,17 @@ https://github.com/ledger/ledger-mode/issues/419"
       (completion-at-point)
       (should
        (equal (buffer-string)
-              "2023-12-23 ")))))
+              "2023-12-23 "))
+
+      (erase-buffer)
+      (insert "23")
+      (backward-char)
+      ;; completion uses whole day number, not just the part before point
+      (completion-at-point)
+      (should
+       ;; TODO: Ideally, this should include a trailing space too.
+       (equal (buffer-string)
+              "2023-12-23")))))
 
 (provide 'complete-test)
 

--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -373,10 +373,7 @@ https://github.com/ledger/ledger-mode/issues/419"
   :tags '(complete regress)
   (let ((ledger-complete--current-time-for-testing ;2024-01-21
          (encode-time 0 0 0 21 1 2024))
-        (ledger-default-date-format ledger-iso-date-format)
-        ;; TODO: Set up date completion so that it does not require a specific
-        ;; completion-style setting.
-        (completion-styles '(flex)))
+        (ledger-default-date-format ledger-iso-date-format))
     (ledger-tests-with-temp-file
         "01-19"
       (goto-char (point-max))
@@ -398,8 +395,7 @@ https://github.com/ledger/ledger-mode/issues/419"
   :tags '(complete regress)
   (let ((ledger-complete--current-time-for-testing ;2024-01-21
          (encode-time 0 0 0 21 1 2024))
-        (ledger-default-date-format ledger-iso-date-format)
-        (completion-styles '(flex)))
+        (ledger-default-date-format ledger-iso-date-format))
     (ledger-tests-with-temp-file
         "19"
       (goto-char (point-max))


### PR DESCRIPTION
ledger-complete-at-point currently seems completely broken for date completion
(e.g., "19" completes to the 19th of the current month, or the previous month,
whichever date is in the past from today).

I added some regression tests that demonstrate the bugs, and then separate
commits to fix each bug.  I plan to squash the test and fix commits together
when merging.

(@purcell, I spent some time fighting with the CI over some old calling
conventions for functions (func-arity, which didn't exist; and encode-time,
which doesn't support a single argument in Emacs < 27, but the multiple-argument
form is marked "obsolete" in Emacs 29).  What's ledger-mode's policy on
supporting Emacs major versions, is there generally some guideline we follow as
to when we're okay with abandoning support for older versions?)

Fix #419.