### PR TITLE
Attempt to fix flaky ledger-fontify/test-017 on Emacs 25.1

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -102,6 +102,10 @@ The two arguments START and END are character positions."
       (ledger-mode)
       (insert str)
       (font-lock-ensure)
+      ;; This second call appears to prevent `ledger-fontify/test-017' from
+      ;; nondeterministically failing on Emacs 25.1.  When ledger-mode no longer
+      ;; supports that Emacs version, this second call can likely be removed.
+      (font-lock-ensure)
       (buffer-string))))
 
 


### PR DESCRIPTION
I'm not sure why this fix would be necessary, but it seems to make the CI happy.
(I would think `ledger-fontify-extend-region` should be sufficient to make
fontification work reliably, but it's possible Emacs 25.1 is doing something
differently).