### PR TITLE
Remove distinction between interactive and batch tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Byte compilation
       run: emacs --eval "(setq byte-compile-error-on-warn (>= emacs-major-version 26))" -L . --batch -f batch-byte-compile ./*.el
     - name: Tests
-      run: nix shell ${{ matrix.ledger_version || 'nixpkgs#ledger' }} --print-build-logs -c make -C test test-batch
+      run: nix shell ${{ matrix.ledger_version || 'nixpkgs#ledger' }} --print-build-logs -c make -C test
     # This is currently for information only, since a lot of docstrings need fixing up
     - name: Checkdoc
       run: make -C test checkdoc || true

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,15 +16,8 @@ all: compile test
 	$(EMACS_BATCH) --eval "(progn (setq byte-compile-error-on-warn t) (batch-byte-compile))" $<
 
 .PHONY: test
-test: test-interactive test-batch
-
-.PHONY: test-interactive
-test-interactive: compile
-	$(EMACS_INTERACTIVE) $(addprefix --load ,$(ERT)) --eval "(ert-run-tests-interactively (quote (tag interactive)))"
-
-.PHONY: test-batch
-test-batch: compile
-	$(EMACS_BATCH) $(addprefix --load ,$(ERT)) --eval "(ert-run-tests-batch-and-exit (quote (not (tag interactive))))"
+test: compile
+	$(EMACS_BATCH) $(addprefix --load ,$(ERT)) -f ert-run-tests-batch-and-exit
 
 .PHONY: compile
 compile: $(ELC)

--- a/test/mode-test.el
+++ b/test/mode-test.el
@@ -37,22 +37,20 @@
       demo-ledger
 
     (goto-char (point-min))              ; beginning-of-buffer
-    ;; See http://stackoverflow.com/questions/32961823/how-can-i-test-an-interactive-function-in-emacs
-    ;; for an explanation of unread-command-events trick
     (should (string= ""
-                     (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
+                     (ledger-tests-with-simulated-input "RET"
                        (ledger-read-account-with-prompt "Account to reconcile"))))
     (forward-line)
     (should (string= "Assets:Checking"
-                     (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
+                     (ledger-tests-with-simulated-input "RET"
                        (ledger-read-account-with-prompt "Account to reconcile"))))
     (forward-line)
     (should (string= "Equity:Opening Balances"
-                     (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
+                     (ledger-tests-with-simulated-input "RET"
                        (ledger-read-account-with-prompt "Account to reconcile"))))
     (forward-line)
     (should (string= ""
-                     (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
+                     (ledger-tests-with-simulated-input "RET"
                        (ledger-read-account-with-prompt "Account to reconcile"))))
     ))
 

--- a/test/mode-test.el
+++ b/test/mode-test.el
@@ -34,27 +34,27 @@
   :tags '(mode baseline interactive)
 
   (ledger-tests-with-temp-file
-   demo-ledger
+      demo-ledger
 
-   (goto-char (point-min))              ; beginning-of-buffer
-   ;; See http://stackoverflow.com/questions/32961823/how-can-i-test-an-interactive-function-in-emacs
-   ;; for an explanation of unread-command-events trick
-   (should (string= ""
-                    (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
-                      (ledger-read-account-with-prompt "Account to reconcile"))))
-   (forward-line)
-   (should (string= "Assets:Checking"
-                    (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
-                      (ledger-read-account-with-prompt "Account to reconcile"))))
-   (forward-line)
-   (should (string= "Equity:Opening Balances"
-                    (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
-                      (ledger-read-account-with-prompt "Account to reconcile"))))
-   (forward-line)
-   (should (string= ""
-                    (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
-                      (ledger-read-account-with-prompt "Account to reconcile"))))
-   ))
+    (goto-char (point-min))              ; beginning-of-buffer
+    ;; See http://stackoverflow.com/questions/32961823/how-can-i-test-an-interactive-function-in-emacs
+    ;; for an explanation of unread-command-events trick
+    (should (string= ""
+                     (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
+                       (ledger-read-account-with-prompt "Account to reconcile"))))
+    (forward-line)
+    (should (string= "Assets:Checking"
+                     (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
+                       (ledger-read-account-with-prompt "Account to reconcile"))))
+    (forward-line)
+    (should (string= "Equity:Opening Balances"
+                     (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
+                       (ledger-read-account-with-prompt "Account to reconcile"))))
+    (forward-line)
+    (should (string= ""
+                     (let ((unread-command-events (listify-key-sequence (kbd "RET"))))
+                       (ledger-read-account-with-prompt "Account to reconcile"))))
+    ))
 
 
 (ert-deftest ledger-mode/test-002 ()

--- a/test/mode-test.el
+++ b/test/mode-test.el
@@ -31,7 +31,7 @@
 
 (ert-deftest ledger-mode/test-001 ()
   "Test ledger-read-account-with-prompt (used in ledger-reconcile)"
-  :tags '(mode baseline interactive)
+  :tags '(mode baseline)
 
   (ledger-tests-with-temp-file
       demo-ledger


### PR DESCRIPTION
This PR makes it possible to run `ledger-mode/test-001` (the only test tagged
`interactive`) in batch mode, and thus lets all tests be run in a uniform way.
This change was prompted by an attempt to switch to using makem.sh for testing
and linting purposes.