### PR TITLE
Remove unused ledger-occur-narrowed-face

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -22,6 +22,9 @@ amount that would balance the transaction.
 This option defaults to t.  When nil, links in the report buffer visit the
 specific posting at point, rather than the beginning of the transaction
 containing that posting.
+** Removed unused ledger-occur-narrowed-face
+This face was not actually used to mark up narrowed text, which is instead
+hidden by using overlays.
 * Release v4.0.0
 ** The completion system now respects whatever completion system the user prefers
 Some users prefer different completion systems such as ivy or helm. To get the

--- a/ledger-fonts.el
+++ b/ledger-fonts.el
@@ -394,11 +394,6 @@
   "Face for Ledger dates"
   :group 'ledger-faces)
 
-(defface ledger-occur-narrowed-face
-  `((t :inherit font-lock-comment-face :invisible t))
-  "Default face for Ledger occur mode hidden transactions"
-  :group 'ledger-faces)
-
 (defface ledger-occur-xact-face
   `((t :inherit highlight))
   "Default face for Ledger occur mode shown transactions"


### PR DESCRIPTION
The :invisible property is not one supported by defface, and in fact this face is never actually used.

Noticed this via a byte compilation warning in the CI for #438