### PR TITLE
Added check to ignore --date-format option for hledger users

### DIFF
--- a/ledger-exec.el
+++ b/ledger-exec.el
@@ -89,7 +89,7 @@ otherwise the error output is displayed and an error is raised."
                    (apply #'call-process-region
                           (append (list (point-min) (point-max)
                                         ledger-binary-path nil (list outbuf errfile) nil "-f" "-")
-                                  (when (not (string-match "hledger" ledger-binary-path))
+                                  (when ledger-default-date-format
                                     (list "--date-format" ledger-default-date-format))
                                   args)))))
             (if (ledger-exec-success-p exit-code outbuf)

--- a/ledger-exec.el
+++ b/ledger-exec.el
@@ -89,7 +89,8 @@ otherwise the error output is displayed and an error is raised."
                    (apply #'call-process-region
                           (append (list (point-min) (point-max)
                                         ledger-binary-path nil (list outbuf errfile) nil "-f" "-")
-                                  (list "--date-format" ledger-default-date-format)
+                                  (when (not (string-match "hledger" ledger-binary-path))
+                                    (list "--date-format" ledger-default-date-format))
                                   args)))))
             (if (ledger-exec-success-p exit-code outbuf)
                 outbuf

--- a/ledger-init.el
+++ b/ledger-init.el
@@ -59,11 +59,13 @@ Returns the current date if DATE is nil or not supplied.
 
 If FORMAT is provided, use that as the date format.  Otherwise,
 use the --input-date-format specified in `ledger-init-file-name',
-or if none, use `ledger-default-date-format'."
+or if none, use `ledger-default-date-format'. If none of
+the previous values exist, use ledger-iso-date-format."
   (format-time-string
    (or format
        (cdr (assoc "input-date-format" ledger-environment-alist))
-       ledger-default-date-format)
+       ledger-default-date-format
+       ledger-iso-date-format)
    date))
 
 

--- a/ledger-init.el
+++ b/ledger-init.el
@@ -49,7 +49,7 @@ This variable is automatically populated by
   "The date format that ledger uses throughout.
 Set this to the value of `ledger-iso-date-format' if you prefer
 ISO 8601 dates."
-  :type '(choice string (const nil)
+  :type '(choice string (const nil))
   :package-version '(ledger-mode . "4.0.0")
   :group 'ledger)
 

--- a/ledger-init.el
+++ b/ledger-init.el
@@ -49,7 +49,7 @@ This variable is automatically populated by
   "The date format that ledger uses throughout.
 Set this to the value of `ledger-iso-date-format' if you prefer
 ISO 8601 dates."
-  :type 'string
+  :type '(choice string (const nil)
   :package-version '(ledger-mode . "4.0.0")
   :group 'ledger)
 

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -89,7 +89,7 @@ reconcile-finish will mark all pending posting cleared."
 (defcustom ledger-reconcile-default-date-format ledger-default-date-format
   "Date format for the reconcile buffer.
 Default is `ledger-default-date-format'."
-  :type 'string
+  :type '(custom string (const nil))
   :group 'ledger-reconcile)
 
 (defcustom ledger-reconcile-target-prompt-string "Target amount for reconciliation "


### PR DESCRIPTION
This PR intends to improve ledger-mode compatibility for hledger users.
It requires no additional configuration and is completely invisible to ledger users while fixing the most common error hledger users see.

It's "the dumbest thing that works", a simple check whether `ledger-binary-path` points to hledger. If it does, `ledger-exec-ledger` does not include the --date-format option (which hledger doesn't have).

Solves the largest problem for hledger users and is a prerequisite for other improvements (WIP, i plan to make reconcilliation work as well and this is the first step.)
I've documented the incompatibilities in [hledger's documentation](https://hledger.org/editors.html#editor-configuration).

With this change the following now works with hledger:
Quick balance display (\<C-c\> \<C-p\>)
Add transaction (\<C-c\> \<C-a\>)
Display ledger stats (\<C-c\> \<C-l\>)