### PR TITLE
CI: Fix usage of soon-to-be obsolete items

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,17 +15,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        emacs_version: [25.1, 25.2, 25.3, 26.1, 26.2, 26.3, 27.1, 27.2, 28.1, 28.2, 29.1, 29.3, 30.1, snapshot]
+        emacs_version: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1, 28.2, 29.1, 29.3, 30.1, snapshot]
         experimental: [false]
 
         # Exclude Emacs versions that are unavailable on Apple Silicon
         exclude:
-          - emacs_version: 25.1
-            os: macos-latest
-          - emacs_version: 25.2
-            os: macos-latest
-          - emacs_version: 25.3
-            os: macos-latest
           - emacs_version: 26.1
             os: macos-latest
           - emacs_version: 26.2

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,5 +1,5 @@
 * Development (v4.1)
-** Ledger-mode now requires Emacs 25 or later
+** Ledger-mode now requires Emacs 26 or later
 ** ledger-add-transaction now uses org-read-date
 This is more consistent with the behavior of =ledger-copy-transaction-at-point=
 and =ledger-insert-effective-date=. In order to disable the pop-up calendar, bind

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -99,7 +99,7 @@
 (defun ledger-read-payee-with-prompt (prompt)
   "Read a payee from the minibuffer with PROMPT."
   (ledger-completing-read-with-default prompt
-                                       (when-let ((payee (ledger-xact-payee)))
+                                       (when-let* ((payee (ledger-xact-payee)))
                                          (regexp-quote payee))
                                        (ledger-payees-list)))
 

--- a/ledger-occur.el
+++ b/ledger-occur.el
@@ -150,8 +150,8 @@ Argument OVL-BOUNDS contains bounds for the transactions to be left visible."
       ;; Search loop
       (while (not (eobp))
         ;; if something found
-        (when-let ((endpoint (re-search-forward regex nil 'end))
-                   (bounds (ledger-navigate-find-element-extents endpoint)))
+        (when-let* ((endpoint (re-search-forward regex nil 'end))
+                    (bounds (ledger-navigate-find-element-extents endpoint)))
           (push bounds lines)
           ;; move to the end of the xact, no need to search inside it more
           (goto-char (cadr bounds))))

--- a/ledger-post.el
+++ b/ledger-post.el
@@ -210,7 +210,7 @@ Error if the commodities do not match."
       (cl-loop
        while (re-search-forward ledger-post-line-regexp end t)
        for account-end = (match-end ledger-regex-post-line-group-account)
-       for amount-string = (when-let ((amount-string (match-string ledger-regex-post-line-group-amount)))
+       for amount-string = (when-let* ((amount-string (match-string ledger-regex-post-line-group-amount)))
                              (unless (string-empty-p (string-trim amount-string))
                                amount-string))
        if (not amount-string)

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -221,9 +221,9 @@ described above."
   "Display the cleared-or-pending balance.
 And calculate the target-delta of the account being reconciled."
   (interactive)
-  (when-let (pending (ledger-reconcile-get-cleared-or-pending-balance ledger-reconcile-ledger-buf ledger-reconcile-account))
+  (when-let* ((pending (ledger-reconcile-get-cleared-or-pending-balance ledger-reconcile-ledger-buf ledger-reconcile-account)))
     (let ((message
-           (if-let (diff (and ledger-reconcile-target (ledger-subtract-commodity ledger-reconcile-target pending)))
+           (if-let* ((diff (and ledger-reconcile-target (ledger-subtract-commodity ledger-reconcile-target pending))))
                (progn
                  (setq ledger-reconcile-last-balance-equals-target (zerop (car diff)))
                  (format-message "Cleared and Pending balance: %s,   Difference from target: %s"

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -432,8 +432,8 @@ called in the ledger buffer for which the report is being run."
     (with-temp-buffer
       (save-excursion (insert report-cmd))
       (while (re-search-forward "%(\\([^)]*\\))" nil t)
-        (when-let ((specifier (match-string 1))
-                   (f (cdr (assoc specifier ledger-report-format-specifiers))))
+        (when-let* ((specifier (match-string 1))
+                    (f (cdr (assoc specifier ledger-report-format-specifiers))))
           (let* ((arg (save-match-data
                         (with-current-buffer ledger-buf
                           (funcall f))))
@@ -442,7 +442,7 @@ called in the ledger buffer for which the report is being run."
                                (string-join arg " ")
                              (shell-quote-argument arg)))))
             (replace-match quoted 'fixedcase 'literal))))
-       (buffer-string))))
+      (buffer-string))))
 
 (defun ledger-report--cmd-needs-links-p (cmd)
   "Check links should be added to the report produced by CMD."
@@ -632,7 +632,7 @@ IGNORE-AUTO and NOCONFIRM are for compatibility with
   (when (string-empty-p ledger-report-name)
     (setq ledger-report-name (ledger-report-read-new-name)))
 
-  (when-let ((existing-name (ledger-report-name-exists ledger-report-name)))
+  (when-let* ((existing-name (ledger-report-name-exists ledger-report-name)))
     (cond ((y-or-n-p (format "Overwrite existing report named '%s'? "
                              ledger-report-name))
            (if (string-equal

--- a/ledger-schedule.el
+++ b/ledger-schedule.el
@@ -103,15 +103,15 @@ COUNT 0) means EVERY day-of-week (eg. every Saturday)"
       (cond ((zerop count) ;; Return true if day-of-week matches
              `(eq (nth 6 (decode-time date)) ,day-of-week))
             ((> count 0) ;; Positive count
-             (let ((decoded (cl-gensym)))
+             (let ((decoded (gensym)))
                `(let ((,decoded (decode-time date)))
                   (and (eq (nth 6 ,decoded) ,day-of-week)
                        (<= ,(* (1- count) 7)
                            (nth 3 ,decoded)
                            ,(* count 7))))))
             ((< count 0)
-             (let ((days-in-month (cl-gensym))
-                   (decoded (cl-gensym)))
+             (let ((days-in-month (gensym))
+                   (decoded (gensym)))
                `(let* ((,decoded (decode-time date))
                        (,days-in-month (ledger-schedule-days-in-month
                                         (nth 4 ,decoded)
@@ -138,9 +138,9 @@ For example every second Friday, regardless of month."
 (defun ledger-schedule-constrain-date-range (month1 day1 month2 day2)
   "Return a form of DATE that is true if DATE falls between two dates.
 The dates are given by the pairs MONTH1 DAY1 and MONTH2 DAY2."
-  (let ((decoded (cl-gensym))
-        (target-month (cl-gensym))
-        (target-day (cl-gensym)))
+  (let ((decoded (gensym))
+        (target-month (gensym))
+        (target-day (gensym)))
     `(let* ((,decoded (decode-time date))
             (,target-month (nth 4 decoded))
             (,target-day (nth 3 decoded)))

--- a/ledger-xact.el
+++ b/ledger-xact.el
@@ -85,12 +85,12 @@ When nil, `ledger-add-transaction' will not prompt twice."
 
 (defun ledger-xact-payee ()
   "Return the payee of the transaction containing point or nil."
-  (when-let ((xact-context (ledger-xact-context)))
+  (when-let* ((xact-context (ledger-xact-context)))
     (ledger-context-field-value xact-context 'payee)))
 
 (defun ledger-xact-date ()
   "Return the date of the transaction containing point or nil."
-  (when-let ((xact-context (ledger-xact-context)))
+  (when-let* ((xact-context (ledger-xact-context)))
     (ledger-context-field-value xact-context 'date)))
 
 (defun ledger-xact-find-slot (moment)
@@ -117,7 +117,7 @@ MOMENT is an encoded date"
          (current-year (nth 5 (decode-time now))))
     (while (not (eobp))
       (when (looking-at ledger-iterate-regexp)
-        (if-let ((year (match-string 1)))
+        (if-let* ((year (match-string 1)))
             (setq current-year (string-to-number year)) ;a Y directive was found
           (let ((start (match-beginning 0))
                 (year (match-string (+ ledger-regex-iterate-group-actual-date 1)))

--- a/test/regex-test.el
+++ b/test/regex-test.el
@@ -79,10 +79,10 @@
     ;; Add symbols in reverse so they are sorted in the correct order as we
     ;; prepend them.
     (dolist (symbol (reverse regex-test--all-ledger-regex-symbols))
-      (when-let (name (seq-find (lambda (name)
-                                  (string-prefix-p (concat "ledger-regex-" name "-")
-                                                   (symbol-name symbol)))
-                                reverse-names))
+      (when-let* ((name (seq-find (lambda (name)
+                                    (string-prefix-p (concat "ledger-regex-" name "-")
+                                                     (symbol-name symbol)))
+                                  reverse-names)))
         (puthash name
                  (cons symbol (gethash name hash-table)) hash-table)))
     hash-table)


### PR DESCRIPTION
if-let, when-let, and gensym are obsolete starting in Emacs 31.1.  This commit
fixes the Emacs snapshot CI build, but unfortunately needs to drop support for
Emacs 25.