### PR TITLE
Refactor step-by-step completion to avoid checking context bounds twice

### DIFF
--- a/ledger-complete.el
+++ b/ledger-complete.el
@@ -200,11 +200,11 @@ an alist (ACCOUNT-ELEMENT . NODE)."
            (root (ledger-accounts-tree))
            (prefix nil))
       (while (cdr elements)
-        (let ((xact (assoc (car elements) root)))
-          (if xact
+        (let ((entry (assoc (car elements) root)))
+          (if entry
               (setq prefix (concat prefix (and prefix ":")
                                    (car elements))
-                    root (cdr xact))
+                    root (cdr entry))
             (setq root nil elements nil)))
         (setq elements (cdr elements)))
       (setq root (delete (list (car elements) t) root))

--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -441,6 +441,25 @@ https://github.com/ledger/ledger-mode/issues/419"
        (equal (buffer-string)
               "2023-12-23 ")))))
 
+(ert-deftest ledger-complete/account-complete-error ()
+  "Regression test for https://github.com/ledger/ledger-mode/issues/443."
+  :tags '(complete regress)
+  (let ((ledger-complete-in-steps t))
+    (ledger-tests-with-temp-file
+        "\
+;
+2025/01/06 * Cinema
+    Expenses:Cinema                           €18.00
+    Cash"
+      (goto-char (point-min))
+      (end-of-line)
+      (insert " ")
+      (let ((completion-in-region-function
+             (lambda (start end collection predicate)
+               (should (null (all-completions (buffer-substring start end)
+                                              collection predicate))))))
+        (call-interactively 'completion-at-point)))))
+
 (provide 'complete-test)
 
 ;;; complete-test.el ends here


### PR DESCRIPTION
This resolves an old FIXME about a wasteful calculation, anyway, but the
motivation is to:

Fix #443