### PR TITLE
Configure a reasonable default outline-regexp

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -25,6 +25,14 @@ containing that posting.
 ** Removed unused ledger-occur-narrowed-face
 This face was not actually used to mark up narrowed text, which is instead
 hidden by using overlays.
+** ledger-mode now sets default outline-regexp
+For =outline-minor-mode= users, ledger-mode now configures a default regexp that
+causes multiline, entries, comments, directives, etc. to be folded by the
+outline commands.
+
+This will not conflict with existing configurations for using
+=outline-minor-mode= to organize large sections of the ledger file, if such
+configurations set =outline-regexp= in =ledger-mode-hook= or local variables.
 * Release v4.0.0
 ** The completion system now respects whatever completion system the user prefers
 Some users prefer different completion systems such as ivy or helm. To get the

--- a/doc/ledger-mode.texi
+++ b/doc/ledger-mode.texi
@@ -1151,7 +1151,7 @@ The column Ledger-mode attempts to align accounts to.
 @item ledger-post-amount-alignment-at
 Position at which the amount is aligned.
 
-Can be @code{:end} to align on the last number of the amount (can be followed 
+Can be @code{:end} to align on the last number of the amount (can be followed
 by unaligned commodity) or @code{:decimal} to align at the decimal separator.
 
 @item ledger-post-amount-alignment-column
@@ -1236,12 +1236,11 @@ configuration:
 @cindex org
 @cindex folding
 @lisp
-(eval-after-load 'ledger-mode
-  (progn
-    ;; org-cycle allows completion to work whereas outline-toggle-children does not
-    (define-key ledger-mode-map (kbd "TAB") #'org-cycle)
-    (add-hook 'ledger-mode-hook #'outline-minor-mode)
-    (font-lock-add-keywords 'ledger-mode outline-font-lock-keywords)))
+(with-eval-after-load 'ledger-mode
+  ;; org-cycle allows completion to work whereas outline-toggle-children does not
+  (define-key ledger-mode-map (kbd "TAB") #'org-cycle)
+  (add-hook 'ledger-mode-hook #'outline-minor-mode)
+  (font-lock-add-keywords 'ledger-mode outline-font-lock-keywords))
 @end lisp
 
 @node Concept Index, Command & Variable Index, Hacking Ledger-mode, Top

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -460,7 +460,9 @@ With prefix ARG, decrement by that many instead."
   (setq-local indent-line-function #'ledger-indent-line)
   (setq-local indent-region-function 'ledger-post-align-postings)
   (setq-local beginning-of-defun-function #'ledger-navigate-beginning-of-xact)
-  (setq-local end-of-defun-function #'ledger-navigate-end-of-xact))
+  (setq-local end-of-defun-function #'ledger-navigate-end-of-xact)
+
+  (setq-local outline-regexp "[^[:space:]]"))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.ledger\\'" . ledger-mode))

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -455,6 +455,8 @@ With prefix ARG, decrement by that many instead."
   (add-hook 'before-revert-hook 'ledger-highlight--before-revert nil t)
   (add-hook 'after-revert-hook 'ledger-highlight-xact-under-point nil t)
 
+  (add-to-invisibility-spec 'ledger-occur-hidden)
+
   (ledger-init-load-init-file)
   (setq-local comment-start ";")
   (setq-local indent-line-function #'ledger-indent-line)

--- a/ledger-occur.el
+++ b/ledger-occur.el
@@ -119,7 +119,7 @@ long, otherwise it is the word at point."
   "Make an overlay for an invisible portion of the buffer, from BEG to END."
   (let ((ovl (make-overlay beg end)))
     (overlay-put ovl ledger-occur-overlay-property-name t)
-    (overlay-put ovl 'invisible t)))
+    (overlay-put ovl 'invisible 'ledger-occur-hidden)))
 
 (defun ledger-occur-create-overlays (ovl-bounds)
   "Create the overlays for the visible transactions.


### PR DESCRIPTION
For `outline-minor-mode` users, ledger-mode now configures a default regexp that
causes multiline, entries, comments, directives, etc. to be folded by the
outline commands.

This will not conflict with existing configurations for using
`outline-minor-mode` to organize large sections of the ledger file, if such
configurations set `outline-regexp` in `ledger-mode-hook` or local variables.