### PR TITLE
Add specific minibuffer history for reading commoditized strings

### DIFF
--- a/ledger-commodities.el
+++ b/ledger-commodities.el
@@ -157,14 +157,22 @@ longer ones are after the value."
         (concat str " " commodity)
       (concat commodity " " str))))
 
-(defun ledger-read-commodity-string (prompt)
-  "Read an amount from mini-buffer using PROMPT."
-  (let ((str (read-from-minibuffer
-              (concat prompt " (" ledger-reconcile-default-commodity "): ")))
-        comm)
-    (when (and (> (length str) 0)
-               (ledger-split-commodity-string str))
-      (setq comm (ledger-split-commodity-string str))
+(defvar ledger-read-commodity-history nil
+  "Default history variable for `ledger-read-commodity-string'.")
+
+(defun ledger-read-commodity-string (prompt &optional history)
+  "Read an amount from mini-buffer using PROMPT.
+
+If not supplied as input, the commodity defaults to
+`ledger-reconcile-default-commodity'.
+
+If HISTORY is non-nil, it should be a minibuffer history variable.
+Otherwise, default to `ledger-read-commodity-history'."
+  (let ((str (read-string
+              (format "%s (%s): " prompt ledger-reconcile-default-commodity)
+              nil (or history 'ledger-read-commodity-history))))
+    (when-let* (((> (length str) 0))
+                (comm (ledger-split-commodity-string str)))
       (if (cadr comm)
           comm
         (list (car comm) ledger-reconcile-default-commodity)))))

--- a/ledger-reconcile.el
+++ b/ledger-reconcile.el
@@ -92,7 +92,7 @@ Default is `ledger-default-date-format'."
   :type 'string
   :group 'ledger-reconcile)
 
-(defcustom ledger-reconcile-target-prompt-string "Target amount for reconciliation "
+(defcustom ledger-reconcile-target-prompt-string "Target amount for reconciliation"
   "Prompt for reconcile target."
   :type 'string
   :group 'ledger-reconcile)
@@ -616,10 +616,16 @@ reconciliation, otherwise prompt for TARGET."
             (ledger-reconcile-change-target target)
           (ledger-display-balance))))))
 
+(defvar ledger-reconcile-target-history nil
+  "Minibuffer history for `ledger-reconcile-change-target'")
+
 (defun ledger-reconcile-change-target (&optional target)
   "Change the TARGET amount for the reconciliation process."
   (interactive)
-  (setq ledger-reconcile-target (or target (ledger-read-commodity-string ledger-reconcile-target-prompt-string)))
+  (setq ledger-reconcile-target
+        (or target (ledger-read-commodity-string
+                    ledger-reconcile-target-prompt-string
+                    'ledger-reconcile-target-history)))
   (ledger-display-balance))
 
 (defun ledger-reconcile--change-sort-key-and-refresh (sort-key)


### PR DESCRIPTION
I got a little annoyed with the minibuffer history for reconcile target and other history being mixed up with my generic minibuffer history, which contained lots of other random numbers and strings.  When redoing a reconcile command it is useful to be able to bring up recent target amounts.