### PR TITLE
Fix interactive running of ERT tests

### DIFF
--- a/test/complete-test.el
+++ b/test/complete-test.el
@@ -303,10 +303,8 @@ account Assets:Checking:Bank B")
 
 (ert-deftest ledger-complete/test-account-completion-in-steps ()
   :tags '(complete)
-  (let ((completion-cycle-threshold t)
-        (ledger-complete-in-steps t))
-    (ledger-tests-with-temp-file
-        "2020-01-01 Opening Balances
+  (ledger-tests-with-temp-file
+      "2020-01-01 Opening Balances
     Assets:Bank:Balance                       100.00 EUR
     Equity:Opening Balances
 
@@ -320,6 +318,8 @@ account Assets:Checking:Bank B")
 
 2020-04-01 Fnord
     As"
+    (let ((completion-cycle-threshold t)
+          (ledger-complete-in-steps t))
       (goto-char (point-max))
       (call-interactively 'completion-at-point)
       (should
@@ -342,11 +342,11 @@ account Assets:Checking:Bank B")
 (ert-deftest ledger-complete/amount-separated-by-tab ()
   "https://github.com/ledger/ledger-mode/issues/339"
   :tags '(complete regress)
-  (let ((ledger-post-auto-align nil))
-    (ledger-tests-with-temp-file
-        "2019/06/28 Foobar
+  (ledger-tests-with-temp-file
+      "2019/06/28 Foobar
 \tExpenses\t11.99 CAD
 \tEx\t-11.99 CAD"
+    (let ((ledger-post-auto-align nil))
       (forward-line 2)
       (forward-word 1)
       (call-interactively 'completion-at-point)
@@ -393,10 +393,10 @@ account Expenses:Groceries
 https://github.com/ledger/ledger-mode/issues/419"
   :tags '(complete regress)
   (let ((ledger-complete--current-time-for-testing ;2024-01-21
-         (encode-time 0 0 0 21 1 2024))
-        (ledger-default-date-format ledger-iso-date-format))
+         (encode-time 0 0 0 21 1 2024)))
     (ledger-tests-with-temp-file
         "01-19"
+      (setq ledger-default-date-format ledger-iso-date-format)
       (goto-char (point-max))
       (completion-at-point)
       (should
@@ -415,10 +415,10 @@ https://github.com/ledger/ledger-mode/issues/419"
 https://github.com/ledger/ledger-mode/issues/419"
   :tags '(complete regress)
   (let ((ledger-complete--current-time-for-testing ;2024-01-21
-         (encode-time 0 0 0 21 1 2024))
-        (ledger-default-date-format ledger-iso-date-format))
+         (encode-time 0 0 0 21 1 2024)))
     (ledger-tests-with-temp-file
         "19"
+      (setq ledger-default-date-format ledger-iso-date-format)
       (goto-char (point-max))
       (completion-at-point)
       (should
@@ -589,10 +589,10 @@ Covers the `(setq root nil elements nil)' arm."
   "Completing a date with month/day in the past of current year.
 Returns this year's date when not already past."
   :tags '(complete)
-  (let ((ledger-complete--current-time-for-testing
-         (encode-time 0 0 0 21 6 2024)) ; 2024-06-21
-        (ledger-default-date-format ledger-iso-date-format))
-    (ledger-tests-with-temp-file "03-15"
+  (ledger-tests-with-temp-file "03-15"
+    (let ((ledger-complete--current-time-for-testing
+           (encode-time 0 0 0 21 6 2024)) ; 2024-06-21
+          (ledger-default-date-format ledger-iso-date-format))
       (goto-char (point-max))
       (completion-at-point)
       (should (equal (buffer-string) "2024-03-15 ")))))
@@ -601,10 +601,10 @@ Returns this year's date when not already past."
   "Completing a day-only when current month is January falls back to Dec last year.
 Covers `last-month'/`last-year' branches in `ledger-complete-date'."
   :tags '(complete)
-  (let ((ledger-complete--current-time-for-testing
-         (encode-time 0 0 0 5 1 2024)) ; 2024-01-05
-        (ledger-default-date-format ledger-iso-date-format))
-    (ledger-tests-with-temp-file "10"
+  (ledger-tests-with-temp-file "10"
+    (let ((ledger-complete--current-time-for-testing
+           (encode-time 0 0 0 5 1 2024)) ; 2024-01-05
+          (ledger-default-date-format ledger-iso-date-format))
       (goto-char (point-max))
       (completion-at-point)
       ;; January has past day 10? No - current is Jan 5. So past day 10 is in
@@ -625,8 +625,8 @@ Covers `last-month'/`last-year' branches in `ledger-complete-date'."
 Covers lines 302-306 in `ledger-complete-at-point' that set
 `start' and `collection' for the effective-date branch."
   :tags '(complete)
-  (let ((ledger-default-date-format ledger-iso-date-format))
-    (ledger-tests-with-temp-file "2024-06-15=06-20"
+  (ledger-tests-with-temp-file "2024-06-15=06-20"
+    (let ((ledger-default-date-format ledger-iso-date-format))
       (goto-char (point-max))
       (let ((res (ledger-complete-test--call-capf-table)))
         (should res)

--- a/test/reconcile-test.el
+++ b/test/reconcile-test.el
@@ -36,19 +36,20 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=1107"
 
   (ledger-tests-with-temp-file
       demo-ledger
-    (ledger-reconcile "Assets:Checking" '(0 "$")) ; this moves to *reconcile* buffer
-    (other-window 1)                ; go to *ledger* buffer
-    (insert " ")                    ; simulate modification of ledger buffer
-    (delete-char -1)
-    (other-window 1)                ; back to *reconcile* buffer
-    (ledger-reconcile-save)         ; key 's'
-    (should ;; current buffer should be *reconcile* buffer
-     (equal (buffer-name)           ; current buffer name
-            ledger-reconcile-buffer-name))
-    (other-window 1)                ; switch to *other* window
-    (should ;; Expected: this must be ledger buffer
-     (equal (buffer-name)           ; current buffer name
-            (buffer-name ledger-buffer)))))
+    (let ((ledger-buf-window (selected-window)))
+      (ledger-reconcile "Assets:Checking" '(0 "$")) ; this moves to *reconcile* buffer
+      (select-window ledger-buf-window)             ; go to *ledger* buffer
+      (insert " ")                      ; simulate modification of ledger buffer
+      (delete-char -1)
+      (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; back to *reconcile* buffer
+      (ledger-reconcile-save)      ; key 's'
+      (should                      ; current buffer should be *reconcile* buffer
+       (equal (buffer-name)        ; current buffer name
+              ledger-reconcile-buffer-name))
+      (select-window ledger-buf-window) ; switch to *other* window
+      (should                           ; Expected: this must be ledger buffer
+       (equal (buffer-name)             ; current buffer name
+              (buffer-name ledger-buffer))))))
 
 
 (ert-deftest ledger-reconcile/test-002 ()

--- a/test/reconcile-test.el
+++ b/test/reconcile-test.el
@@ -36,7 +36,8 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=1107"
 
   (ledger-tests-with-temp-file
       demo-ledger
-    (let ((ledger-buf-window (selected-window)))
+    (let ((ledger-buf (current-buffer))
+          (ledger-buf-window (selected-window)))
       (ledger-reconcile "Assets:Checking" '(0 "$")) ; this moves to *reconcile* buffer
       (select-window ledger-buf-window)             ; go to *ledger* buffer
       (insert " ")                      ; simulate modification of ledger buffer
@@ -49,7 +50,7 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=1107"
       (select-window ledger-buf-window) ; switch to *other* window
       (should                           ; Expected: this must be ledger buffer
        (equal (buffer-name)             ; current buffer name
-              (buffer-name ledger-buffer))))))
+              (buffer-name ledger-buf))))))
 
 
 (ert-deftest ledger-reconcile/test-002 ()
@@ -358,24 +359,25 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=957"
     Dépense:Alimentation:Restaurant          18,40 €
     Passif:Crédit:BanqueAccord
 "
-    (setq ledger-reconcile-default-commodity "€")
-    (ledger-reconcile "BanqueAccord" '(0 "€"))
-    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
-    (forward-line 2)
-    (ledger-reconcile-visit)
-    (forward-line -1)
-    (goto-char (line-beginning-position)) ; beginning-of-line
-    (insert "    Dépense:Alimentation:Alcool    1,00 €
+    (let ((ledger-buffer (current-buffer)))
+      (setq ledger-reconcile-default-commodity "€")
+      (ledger-reconcile "BanqueAccord" '(0 "€"))
+      (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
+      (forward-line 2)
+      (ledger-reconcile-visit)
+      (forward-line -1)
+      (goto-char (line-beginning-position)) ; beginning-of-line
+      (insert "    Dépense:Alimentation:Alcool    1,00 €
     Dépense:Alimentation:Alcool    1,00 €
     Dépense:Alimentation:Alcool    1,00 €
 ")
-    (save-buffer)
-    (switch-to-buffer-other-window ledger-reconcile-buffer-name)
-    (ledger-reconcile-toggle)
-    (switch-to-buffer-other-window ledger-buffer)
-    (should
-     (equal (buffer-string)
-            "2013/04/20 Petit Casino
+      (save-buffer)
+      (switch-to-buffer-other-window ledger-reconcile-buffer-name)
+      (ledger-reconcile-toggle)
+      (switch-to-buffer-other-window ledger-buffer)
+      (should
+       (equal (buffer-string)
+              "2013/04/20 Petit Casino
     Dépense:Alimentation:Alcool               6,49 €
     Dépense:Alimentation:Alcool    1,00 €
     Dépense:Alimentation:Alcool    1,00 €
@@ -387,24 +389,24 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=957"
     Dépense:Alimentation:Restaurant          18,40 €
     Passif:Crédit:BanqueAccord
 "))
-    (goto-char (point-min))  ; beginning-of-buffer
-    (forward-line 1)
-    (kill-line 4)
-    (save-buffer)
-    (switch-to-buffer-other-window ledger-reconcile-buffer-name)
-    (forward-line -1)
-    (ledger-reconcile-toggle)
-    (switch-to-buffer-other-window ledger-buffer)
-    (should
-     (equal (buffer-string)
-            "2013/04/20 Petit Casino
+      (goto-char (point-min))  ; beginning-of-buffer
+      (forward-line 1)
+      (kill-line 4)
+      (save-buffer)
+      (switch-to-buffer-other-window ledger-reconcile-buffer-name)
+      (forward-line -1)
+      (ledger-reconcile-toggle)
+      (switch-to-buffer-other-window ledger-buffer)
+      (should
+       (equal (buffer-string)
+              "2013/04/20 Petit Casino
     Dépense:Alimentation:Épicerie
     Passif:Crédit:BanqueAccord              -14,94 €
 
 2013/04/20 Les Tilleuls
     Dépense:Alimentation:Restaurant          18,40 €
     Passif:Crédit:BanqueAccord
-"))))
+")))))
 
 
 (ert-deftest ledger-reconcile/test-013 ()
@@ -414,17 +416,18 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=906"
 
   (ledger-tests-with-temp-file
       demo-ledger
-    (goto-char 1040)
-    (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
-    (switch-to-buffer-other-window ledger-buffer)
-    (should (= 1040 (point)))
+    (let ((ledger-buffer (current-buffer)))
+      (goto-char 1040)
+      (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
+      (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
+      (switch-to-buffer-other-window ledger-buffer)
+      (should (= 1040 (point)))
 
-    (goto-char 1265)
-    (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
-    (switch-to-buffer-other-window ledger-buffer)
-    (should (= 1265 (point)))))
+      (goto-char 1265)
+      (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
+      (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
+      (switch-to-buffer-other-window ledger-buffer)
+      (should (= 1265 (point))))))
 
 
 (ert-deftest ledger-reconcile/test-014 ()
@@ -434,16 +437,17 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=900"
 
   (ledger-tests-with-temp-file
       demo-ledger
-    (ledger-reconcile "Assets:Checking" '(0 "$"))
-    (select-window (get-buffer-window ledger-reconcile-buffer-name))
-    (switch-to-buffer-other-window ledger-buffer)
-    (save-buffer)
-    (let ((ledger-buffer-name (buffer-name ledger-buffer)))
-      (find-alternate-file temp-file)
-      (ledger-reconcile "Expenses:Books" '(0 "$"))
-      (should ;; Expected: buffer with same name
-       (equal (buffer-name (current-buffer))
-              ledger-buffer-name)))))
+    (let ((ledger-buffer (current-buffer)))
+      (ledger-reconcile "Assets:Checking" '(0 "$"))
+      (select-window (get-buffer-window ledger-reconcile-buffer-name))
+      (switch-to-buffer-other-window ledger-buffer)
+      (save-buffer)
+      (let ((ledger-buffer-name (buffer-name ledger-buffer)))
+        (find-alternate-file (buffer-file-name ledger-buffer))
+        (ledger-reconcile "Expenses:Books" '(0 "$"))
+        (should ;; Expected: buffer with same name
+         (equal (buffer-name (current-buffer))
+                ledger-buffer-name))))))
 
 
 (ert-deftest ledger-reconcile/test-015 ()
@@ -526,18 +530,19 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=879"
 
   (ledger-tests-with-temp-file
       demo-ledger
-    (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
-    (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
-    (switch-to-buffer-other-window ledger-buffer)
-    (ledger-reconcile "Food" '(0 "$")) ; launch a *second* time on *another* account
-    (select-window (get-buffer-window ledger-reconcile-buffer-name))
-    (should ;; current buffer should be *reconcile* buffer
-     (equal (buffer-name)           ; current buffer name
-            ledger-reconcile-buffer-name))
-    (other-window 1)                ; switch to *other* window
-    (should ;; Expected: this must be ledger buffer
-     (equal (buffer-name)           ; current buffer name
-            (buffer-name ledger-buffer)))))
+    (let ((ledger-buffer (current-buffer)))
+      (ledger-reconcile "Assets:Checking" '(0 "$")) ; launch reconciliation
+      (select-window (get-buffer-window ledger-reconcile-buffer-name)) ; IRL user select reconcile window
+      (switch-to-buffer-other-window ledger-buffer)
+      (ledger-reconcile "Food" '(0 "$")) ; launch a *second* time on *another* account
+      (select-window (get-buffer-window ledger-reconcile-buffer-name))
+      (should ;; current buffer should be *reconcile* buffer
+       (equal (buffer-name)           ; current buffer name
+              ledger-reconcile-buffer-name))
+      (other-window 1)                ; switch to *other* window
+      (should ;; Expected: this must be ledger buffer
+       (equal (buffer-name)           ; current buffer name
+              (buffer-name ledger-buffer))))))
 
 
 (ert-deftest ledger-reconcile/test-020 ()
@@ -702,22 +707,23 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=262"
 
   (ledger-tests-with-temp-file
       demo-ledger
-    (ledger-reconcile "Expenses" '(0 "$"))
-    (select-window (get-buffer-window ledger-reconcile-buffer-name))
-    (forward-line 2)       ; because of ledger-reconcile-buffer-header
-    (forward-line 4)       ; move to not be on first line of reconcile
-    (let ((line-before-delete (line-number-at-pos)))
-      (ledger-reconcile-delete)             ; key 'd'
-      (should ;; Expected: line position is kept
-       (eq line-before-delete (line-number-at-pos)))
-      (should ;; current buffer should be *reconcile* buffer
-       (equal (buffer-name)           ; current buffer name
-              ledger-reconcile-buffer-name))
-      (other-window 1)                ; switch to *other* window
-      (should ;; Expected: this must be ledger buffer
-       (equal (buffer-name)           ; current buffer name
-              (buffer-name ledger-buffer)))
-      (should (= 1322 (point))))))    ; expected on "Book Store" xact
+    (let ((ledger-buffer (current-buffer)))
+      (ledger-reconcile "Expenses" '(0 "$"))
+      (select-window (get-buffer-window ledger-reconcile-buffer-name))
+      (forward-line 2)       ; because of ledger-reconcile-buffer-header
+      (forward-line 4)       ; move to not be on first line of reconcile
+      (let ((line-before-delete (line-number-at-pos)))
+        (ledger-reconcile-delete)             ; key 'd'
+        (should ;; Expected: line position is kept
+         (eq line-before-delete (line-number-at-pos)))
+        (should ;; current buffer should be *reconcile* buffer
+         (equal (buffer-name)           ; current buffer name
+                ledger-reconcile-buffer-name))
+        (other-window 1)                ; switch to *other* window
+        (should ;; Expected: this must be ledger buffer
+         (equal (buffer-name)           ; current buffer name
+                (buffer-name ledger-buffer)))
+        (should (= 1322 (point)))))))    ; expected on "Book Store" xact
 
 
 (ert-deftest ledger-reconcile/test-028 ()

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -502,15 +502,15 @@
 https://github.com/ledger/ledger-mode/issues/424"
   :tags '(report regress)
 
-  (let ((ledger-reports
-         (cons '("dummy-report-name"
-                 "%(binary) -f %(ledger-file) reg --strict --period %(month) %(account)")
-               ledger-reports))
-        (ledger-report-format-specifiers
-         (cl-list* '("account" . report-test--dummy-format-specifier)
-                   ledger-report-format-specifiers))
-        (report-test--account-format-specifier-called-p nil))
-    (ledger-tests-with-temp-file demo-ledger
+  (ledger-tests-with-temp-file demo-ledger
+    (let ((ledger-reports
+           (cons '("dummy-report-name"
+                   "%(binary) -f %(ledger-file) reg --strict --period %(month) %(account)")
+                 ledger-reports))
+          (ledger-report-format-specifiers
+           (cl-list* '("account" . report-test--dummy-format-specifier)
+                     ledger-report-format-specifiers))
+          (report-test--account-format-specifier-called-p nil))
       (ledger-report "dummy-report-name" nil)
       (should report-test--account-format-specifier-called-p)
       ;; `ledger-report-cmd' keeps the raw template so format specifiers

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -92,28 +92,31 @@ provided (e.g., if BODY is still inside a minibuffer prompt)."
   (declare (indent 1) (debug t))
   `(ledger-tests-with-simulated-input-1 ,keys (lambda () ,@body)))
 
+(defun ledger-tests-with-temp-file-1 (contents body)
+  (let* ((temp-file (make-temp-file "ledger-tests-"))
+         (ledger-buffer (find-file-noselect temp-file))
+         (ledger-init-file-name nil))
+    (unwind-protect
+        (with-current-buffer ledger-buffer
+          (switch-to-buffer ledger-buffer) ; this selects window
+          (ledger-mode)
+          (insert contents)
+          (goto-char (point-min))
+          (funcall body))
+      (when (buffer-live-p ledger-buffer)
+        (with-current-buffer ledger-buffer
+          (set-buffer-modified-p nil)
+          (kill-buffer)))
+      (ledger-tests-reset-custom-values 'ledger)
+      (delete-file temp-file))))
+
 (defmacro ledger-tests-with-temp-file (contents &rest body)
   ;; from python-tests-with-temp-file
   "Create a `ledger-mode' enabled file with CONTENTS.
 BODY is code to be executed within the temp buffer.  Point is
 always located at the beginning of buffer."
   (declare (indent 1) (debug t))
-  `(let* ((temp-file (make-temp-file "ledger-tests-"))
-          (ledger-buffer (find-file-noselect temp-file))
-          (ledger-init-file-name nil))
-     (unwind-protect
-         (with-current-buffer ledger-buffer
-           (switch-to-buffer ledger-buffer) ; this selects window
-           (ledger-mode)
-           (insert ,contents)
-           (goto-char (point-min))
-           ,@body)
-       (when (buffer-live-p ledger-buffer)
-         (with-current-buffer ledger-buffer
-           (set-buffer-modified-p nil)
-           (kill-buffer)))
-       (ledger-tests-reset-custom-values 'ledger)
-       (delete-file temp-file))))
+  `(ledger-tests-with-temp-file-1 ,contents (lambda () ,@body)))
 
 (defmacro ledger-tests-with-time-zone (tz &rest body)
   "Temporarily set local time zone to TZ while executing BODY."

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -47,6 +47,7 @@
       (cond ((eq (cadr member) 'custom-group)
              (ledger-tests-reset-custom-values (car member)))
             ((eq (cadr member) 'custom-variable)
+             (put (car member) 'saved-value nil)
              (custom-reevaluate-setting (car member)))))))
 
 (defun ledger-tests-with-simulated-input-1 (keys f)
@@ -96,6 +97,7 @@ provided (e.g., if BODY is still inside a minibuffer prompt)."
   (let* ((temp-file (make-temp-file "ledger-tests-"))
          (ledger-buffer (find-file-noselect temp-file))
          (ledger-init-file-name nil))
+    (ledger-tests-reset-custom-values 'ledger)
     (unwind-protect
         (with-current-buffer ledger-buffer
           (switch-to-buffer ledger-buffer) ; this selects window


### PR DESCRIPTION
This PR consists of a few commits cleaning up some issues with running the
ledger ERT tests interactively.  Some of them are still a little unreliable, but
this PR makes the following improvements:

1. Do not depend on the user's customizations, if any.
   `ledger-tests-with-temp-file` will now reset ledger customizations to the
   actual defaults and not the user's customized value.  (This will also affect
   the user's session, if they're running the ledger tests in their regular
   Emacs, but that is hard to avoid.)
1. Fix some macro hygiene issues with `ledger-tests-with-temp-file`
1. Fix some incorrect assumptions about the selected window prior to the test
   beginning to run.