### PR TITLE
ledger-report: expand format specifiers at run time (fixes ledger#1172)

### DIFF
--- a/ledger-report.el
+++ b/ledger-report.el
@@ -162,7 +162,12 @@ Calls `shrink-window-if-larger-than-buffer'."
 (defvar ledger-report-buffer-name "*Ledger Report*")
 
 (defvar-local ledger-report-name nil)
-(defvar-local ledger-report-cmd nil)
+(defvar-local ledger-report-cmd nil
+  "The raw command template for the current ledger report buffer.
+Format specifiers such as %(binary) and %(ledger-file) are left
+unexpanded and resolved at execution time in `ledger-do-report',
+so the current values of `ledger-binary-path' and the ledger file
+take effect on each run.")
 (defvar-local ledger-report-saved nil)
 (defvar-local ledger-report-current-month nil)
 (defvar-local ledger-report-is-reversed nil)
@@ -339,7 +344,7 @@ returns nil."
 (defun ledger-report-read-command (report-cmd)
   "Read the command line to create a report from REPORT-CMD."
   (read-from-minibuffer "Report command line: "
-                        (if (null report-cmd) "ledger " report-cmd)
+                        (if (null report-cmd) "%(binary) " report-cmd)
                         nil nil 'ledger-report-cmd-prompt-history))
 
 (defun ledger-report-ledger-file-format-specifier ()
@@ -465,13 +470,19 @@ called in the ledger buffer for which the report is being run."
 
 (defun ledger-report-cmd (report-name edit)
   "Get the command line to run the report name REPORT-NAME.
-Optionally EDIT the command."
+Optionally EDIT the command.
+
+The returned command retains its format specifiers (e.g., %(binary)
+and %(ledger-file)) so that `ledger-do-report' can expand them each
+time the report runs.  This keeps saved reports in `ledger-reports'
+responsive to later changes in `ledger-binary-path' or the current
+ledger file, rather than baking in the values observed when the
+report was first run."
   (let ((report-cmd (car (cdr (assoc report-name ledger-reports)))))
     ;; logic for substitution goes here
     (when (or (null report-cmd) edit)
       (setq report-cmd (ledger-report-read-command report-cmd))
       (setq ledger-report-saved nil)) ;; this is a new report, or edited report
-    (setq report-cmd (ledger-report-expand-format-specifiers report-cmd))
     (setq ledger-report-cmd report-cmd)
     (or (string-empty-p report-name)
         (ledger-report-name-exists report-name)
@@ -518,16 +529,19 @@ Optionally EDIT the command."
 
 (defun ledger-do-report (cmd)
   "Run a report command line CMD.
-CMD may contain a (shell-quoted) version of
-`ledger-report--extra-args-marker', which will be replaced by
-arguments returned by `ledger-report--compute-extra-args'."
+CMD may contain format specifiers (e.g., %(binary), %(ledger-file))
+which are expanded via `ledger-report-expand-format-specifiers'
+each time the report runs.  It may also contain a (shell-quoted)
+version of `ledger-report--extra-args-marker', which will be
+replaced by arguments returned by `ledger-report--compute-extra-args'."
   (goto-char (point-min))
-  (let* ((marker ledger-report--extra-args-marker)
+  (let* ((expanded-cmd (ledger-report-expand-format-specifiers cmd))
+         (marker ledger-report--extra-args-marker)
          (marker-re (concat " *" (regexp-quote marker)))
-         (args (ledger-report--compute-extra-args cmd))
+         (args (ledger-report--compute-extra-args expanded-cmd))
          (args-str (concat " " (mapconcat #'shell-quote-argument args " ")))
-         (clean-cmd (replace-regexp-in-string marker-re "" cmd t t))
-         (real-cmd (replace-regexp-in-string marker-re args-str cmd t t)))
+         (clean-cmd (replace-regexp-in-string marker-re "" expanded-cmd t t))
+         (real-cmd (replace-regexp-in-string marker-re args-str expanded-cmd t t)))
     (setq header-line-format
           (and ledger-report-use-header-line
                `(:eval (ledger-report--compute-header-line ,clean-cmd))))
@@ -541,7 +555,7 @@ arguments returned by `ledger-report--compute-extra-args'."
         (setq report (ansi-color-apply report)))
       (save-excursion
         (insert report))
-      (when (ledger-report--cmd-needs-links-p cmd)
+      (when (ledger-report--cmd-needs-links-p expanded-cmd)
         (save-excursion
           (ledger-report--add-links))))))
 

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -184,9 +184,9 @@
 (ert-deftest ledger-report/read-command-default ()
   (cl-letf (((symbol-function 'read-from-minibuffer)
              (lambda (_prompt initial &rest _rest) initial)))
-    (should (string= "ledger " (ledger-report-read-command nil)))
-    (should (string= "ledger bal X"
-                     (ledger-report-read-command "ledger bal X")))))
+    (should (string= "%(binary) " (ledger-report-read-command nil)))
+    (should (string= "%(binary) bal X"
+                     (ledger-report-read-command "%(binary) bal X")))))
 
 
 ;;; Header function ------------------------------------------------------
@@ -513,14 +513,59 @@ https://github.com/ledger/ledger-mode/issues/424"
     (ledger-tests-with-temp-file demo-ledger
       (ledger-report "dummy-report-name" nil)
       (should report-test--account-format-specifier-called-p)
+      ;; `ledger-report-cmd' keeps the raw template so format specifiers
+      ;; are re-evaluated on every run, letting saved reports respect
+      ;; later changes to `ledger-binary-path' and the current ledger
+      ;; file (issue ledger/ledger#1172).
       (should (equal (buffer-local-value
                       'ledger-report-cmd
                       (get-buffer ledger-report-buffer-name))
-                     (concat "ledger [[ledger-mode-flags]] -f "
-                             buffer-file-name
-                             " reg --strict --period "
-                             (ledger-report-month-format-specifier)
-                             " ''"))))))
+                     "%(binary) -f %(ledger-file) reg --strict --period %(month) %(account)")))))
+
+(ert-deftest ledger-report/binary-path-not-baked-in ()
+  "Regression test for ledger/ledger#1172.
+Saved reports must keep the %(binary) format specifier unexpanded
+so changes to `ledger-binary-path' take effect on subsequent runs."
+  :tags '(report regress)
+  (let* ((unique-name (format "ledger-report-1172-%d" (random 100000)))
+         (ledger-reports (copy-tree ledger-reports)))
+    (cl-letf (((symbol-function 'ledger-reports-custom-save) #'ignore)
+              ((symbol-function 'ledger-report-read-command)
+               (lambda (&rest _)
+                 "%(binary) -f %(ledger-file) bal"))
+              ((symbol-function 'ledger-do-report) #'ignore))
+      (ledger-tests-with-temp-file demo-ledger
+        (let ((ledger-binary-path "ledger-initial"))
+          (ledger-report unique-name nil))
+        ;; The saved command must still contain the raw %(binary)
+        ;; specifier rather than the expanded "ledger-initial" path.
+        (let ((saved-cmd (car (cdr (assoc unique-name ledger-reports)))))
+          (should saved-cmd)
+          (should (string-match-p (regexp-quote "%(binary)") saved-cmd))
+          (should-not (string-match-p "ledger-initial" saved-cmd)))
+        ;; The buffer-local command is likewise the raw template.
+        (should (equal (buffer-local-value
+                        'ledger-report-cmd
+                        (get-buffer ledger-report-buffer-name))
+                       "%(binary) -f %(ledger-file) bal"))))))
+
+(ert-deftest ledger-report/binary-path-expansion-dynamic ()
+  "Regression test for ledger/ledger#1172.
+Format specifiers like %(binary) are expanded fresh at each
+invocation of `ledger-report-expand-format-specifiers', so updates
+to `ledger-binary-path' between runs are honored."
+  :tags '(report regress)
+  (ledger-tests-with-temp-file demo-ledger
+    (let ((ledger-report-ledger-buf (current-buffer))
+          (template "%(binary) -f %(ledger-file) bal"))
+      (let ((ledger-binary-path "first-ledger"))
+        (should (string-match-p
+                 "first-ledger"
+                 (ledger-report-expand-format-specifiers template))))
+      (let ((ledger-binary-path "second-ledger"))
+        (let ((expanded (ledger-report-expand-format-specifiers template)))
+          (should (string-match-p "second-ledger" expanded))
+          (should-not (string-match-p "first-ledger" expanded)))))))
 
 
 ;;; Additional fill-in tests for residual gaps -------------------------


### PR DESCRIPTION
## Summary

- Delay `%(binary)`, `%(ledger-file)`, etc. expansion from `ledger-report-cmd` to `ledger-do-report`, so each run of a report picks up the current value of `ledger-binary-path` and the current master file instead of the values observed when the report was first invoked.
- Update the initial minibuffer default in `ledger-report-read-command` from the literal `\"ledger \"` to `\"%(binary) \"` so freshly-authored commands inherit the same dynamic behaviour as the built-in reports.
- Add ERT regression coverage and adjust the existing `ledger-report/test-001` expectation (the buffer-local `ledger-report-cmd` now stores the raw template).

Fixes [ledger/ledger#1172](https://github.com/ledger/ledger/issues/1172).

## Background

Issue ledger/ledger#1172 (filed by @taksuyu) reports:

> When a report command runs it doesn't look the the ledger binary path leading to errors. Also if this path were to change, because the variable is pre-evaluated it won't respect the change.

Before this change, `ledger-report-cmd` called `ledger-report-expand-format-specifiers` on the template at report-creation time and stored the result in `ledger-reports` via `ledger-reports-add`/`ledger-reports-custom-save`. That meant the saved entry contained a path like `/usr/local/bin/ledger` rather than `%(binary)`, so later changes to `ledger-binary-path` had no effect on named reports and `ledger-report-redo` kept using the stale value.

## Test plan

- [x] `make -C test test` (237/237 tests pass).
- [x] Verified new regression tests fail against the unmodified `ledger-report.el` and pass against the fix.