### PR TITLE
Improve test robustness

### DIFF
--- a/ledger-exec.el
+++ b/ledger-exec.el
@@ -35,6 +35,9 @@
 (defvar ledger-works nil
   "Non-nil if the ledger binary can support `ledger-mode' interactive features.")
 
+(defvar ledger-exec--args-only nil
+  "Internal variable, used for testing.")
+
 (defgroup ledger-exec nil
   "Interface to the Ledger command-line accounting program."
   :group 'ledger)
@@ -90,6 +93,8 @@ otherwise the error output is displayed and an error is raised."
                           (append (list (point-min) (point-max)
                                         ledger-binary-path nil (list outbuf errfile) nil "-f" "-")
                                   (list "--date-format" ledger-default-date-format)
+                                  (when ledger-exec--args-only
+                                    (list "--args-only"))
                                   args)))))
             (if (ledger-exec-success-p exit-code outbuf)
                 outbuf

--- a/ledger-init.el
+++ b/ledger-init.el
@@ -27,7 +27,9 @@
 ;;; Code:
 
 (defcustom ledger-init-file-name "~/.ledgerrc"
-  "Location of the ledger initialization file.  nil if you don't have one."
+  "Location of the ledger initialization file.
+
+nil if you don't have one or don't wish to read it."
   :type '(choice (const :tag "Do not read ledger initialization file" nil)
                  file)
   :group 'ledger-exec)

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -421,7 +421,7 @@ MONTH is of the form (YEAR . INDEX) where INDEX ranges from
 
 (defun ledger-report-month-format-specifier ()
   "Substitute current month."
-  (with-current-buffer (or ledger-report-buffer-name (current-buffer))
+  (with-current-buffer ledger-report-buffer-name
     (let* ((month (or ledger-report-current-month (ledger-report--current-month)))
            (year (car month))
            (month-index (cdr month)))

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -432,7 +432,9 @@ MONTH is of the form (YEAR . INDEX) where INDEX ranges from
 
 Format specifiers are defined in the
 `ledger-report-format-specifiers' alist.  The functions are
-called in the ledger buffer for which the report is being run."
+called in the ledger buffer for which the report is being run.
+
+This function must be called from a report buffer."
   (let ((ledger-buf ledger-report-ledger-buf))
     (with-temp-buffer
       (save-excursion (insert report-cmd))

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -597,7 +597,9 @@ IGNORE-AUTO and NOCONFIRM are for compatibility with
     (user-error "Not in a ledger-mode or ledger-report-mode buffer"))
   (let ((cur-buf (current-buffer)))
     (when (and ledger-report-auto-refresh
-               (get-buffer ledger-report-buffer-name))
+               (get-buffer ledger-report-buffer-name)
+               (with-current-buffer ledger-report-buffer-name
+                 (buffer-live-p ledger-report-ledger-buf)))
       (pop-to-buffer (get-buffer ledger-report-buffer-name))
       (ledger-report-maybe-shrink-window)
       (setq ledger-report-cursor-line-number (line-number-at-pos))

--- a/test/exec-test.el
+++ b/test/exec-test.el
@@ -27,6 +27,7 @@
 
 ;;; Code:
 (require 'subr-x)
+(require 'ledger-exec)
 (require 'test-helper)
 
 
@@ -108,7 +109,8 @@ http://bugs.ledger-cli.org/show_bug.cgi?id=254"
 (ert-deftest ledger-exec/test-default-input-buffer ()
   "When no INPUT-BUFFER is given, `ledger-exec-ledger' uses `ledger-master-file'."
   :tags '(exec)
-  (let* ((tmp (make-temp-file "ledger-master-" nil ".dat")))
+  (let* ((tmp (make-temp-file "ledger-master-" nil ".dat"))
+         (ledger-exec--args-only t))
     (unwind-protect
         (progn
           (with-temp-file tmp

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -698,6 +698,39 @@ to `ledger-binary-path' between runs are honored."
           (kill-buffer ledger-report-buffer-name)))
       (when (file-exists-p tmp) (delete-file tmp)))))
 
+(ert-deftest ledger-report/redo-after-killed-source-buffer ()
+  "Do not refresh report if the source buffer has been killed."
+  :tags '(report regress)
+  :expected-result :failed
+  (let (ledger-buf
+        (reports-run 0))
+    (ledger-tests-with-temp-file demo-ledger
+      (let ((ledger-report-after-report-hook
+             (cons (lambda () (cl-incf reports-run))
+                   ledger-report-after-report-hook)))
+        (setq ledger-buf (current-buffer))
+        (should (= reports-run 0))
+        (ledger-report "bal" nil)
+        (with-current-buffer ledger-report-buffer-name
+          (goto-char (point-min))
+          (should (equal (buffer-substring-no-properties (line-beginning-position)
+                                                         (line-end-position))
+                         "Report: bal"))
+          (should (= reports-run 1)))
+        ;; Saving a ledger-mode buffer reruns any reports
+        (save-buffer)
+        (should (= reports-run 2))))
+    ;; Now, the ledger buffer has been killed.  Open a new one.
+    (should (null (buffer-name ledger-buf)))
+    (ledger-tests-with-temp-file demo-ledger
+      (let ((ledger-report-after-report-hook
+             (cons (lambda () (cl-incf reports-run))
+                   ledger-report-after-report-hook)))
+        ;; Saving a new ledger buffer should not attempt to rerun reports,
+        ;; because the report may depend on buffer-local state from the source
+        ;; buffer where it was created.
+        (save-buffer)
+        (should (= reports-run 2))))))
 
 (provide 'report-test)
 

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -108,31 +108,39 @@
 (ert-deftest ledger-report/expand-format-specifiers ()
   ;; Substitute %(month) and %(foo).  Needs both a ledger-buf and the report
   ;; buffer because month-format-specifier-default switches there.
-  (let ((report-buf (get-buffer-create ledger-report-buffer-name))
-        (src-buf (current-buffer)))
+  ;;
+  ;; `src-buf' can be an arbitrary buffer here.
+  (let ((src-buf (current-buffer)))
     (unwind-protect
-        (let ((ledger-report-current-month '(2024 . 4))
-              (ledger-report-ledger-buf src-buf)
-              (ledger-report-format-specifiers
-               '(("month" . ledger-report-month-format-specifier)
-                 ("foo" . (lambda () "QUOTED ME")))))
-          (let ((result (ledger-report-expand-format-specifiers
-                         "ledger -p %(month) reg %(foo)")))
+        (with-current-buffer (get-buffer-create ledger-report-buffer-name)
+          (ledger-report-mode)
+          (setq ledger-report-current-month '(2024 . 4)
+                ledger-report-ledger-buf src-buf)
+          (let* ((ledger-report-format-specifiers
+                  '(("month" . ledger-report-month-format-specifier)
+                    ("foo" . (lambda () "QUOTED ME"))))
+                 (result (ledger-report-expand-format-specifiers
+                          "ledger -p %(month) reg %(foo)")))
             (should (string-match-p "ledger -p 2024-4 reg" result))
             ;; shell-quote-argument escapes the space, so the literal output
             ;; contains "QUOTED\ ME".
             (should (string-match-p "QUOTED" result))
             (should (string-match-p "ME" result))))
-      (let ((kill-buffer-query-functions nil)) (kill-buffer report-buf)))))
+      (kill-buffer ledger-report-buffer-name))))
 
 (ert-deftest ledger-report/expand-format-specifiers-list ()
   ;; A list-returning specifier is space-joined, not shell-quoted.
-  (let ((ledger-report-ledger-buf (current-buffer))
-        (ledger-report-format-specifiers
-         '(("multi" . (lambda () (list "a" "b" "c"))))))
-    (let ((result (ledger-report-expand-format-specifiers
-                   "ledger %(multi) reg")))
-      (should (string-match-p "ledger a b c reg" result)))))
+  (let ((src-buf (current-buffer)))
+    (unwind-protect
+        (with-current-buffer (get-buffer-create ledger-report-buffer-name)
+          (ledger-report-mode)
+          (setq ledger-report-ledger-buf src-buf)
+          (let* ((ledger-report-format-specifiers
+                  '(("multi" . (lambda () (list "a" "b" "c")))))
+                 (result (ledger-report-expand-format-specifiers
+                          "ledger %(multi) reg")))
+            (should (equal "ledger a b c reg" result))))
+      (kill-buffer ledger-report-buffer-name))))
 
 
 ;;; Header line + extra args ---------------------------------------------

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -100,13 +100,10 @@
     (should (string= "Assets:Bank" (ledger-report-account-format-specifier)))))
 
 (ert-deftest ledger-report/month-format-specifier-default ()
-  ;; The function does `(with-current-buffer (or ledger-report-buffer-name …))',
-  ;; so the report buffer must exist.
-  (let ((buf (get-buffer-create ledger-report-buffer-name)))
-    (unwind-protect
-        (let ((ledger-report-current-month '(2024 . 4)))
-          (should (string= "2024-4" (ledger-report-month-format-specifier))))
-      (let ((kill-buffer-query-functions nil)) (kill-buffer buf)))))
+  (with-current-buffer (get-buffer-create ledger-report-buffer-name)
+    (ledger-report-mode)
+    (setq ledger-report-current-month '(2024 . 4))
+    (should (string= "2024-4" (ledger-report-month-format-specifier)))))
 
 (ert-deftest ledger-report/expand-format-specifiers ()
   ;; Substitute %(month) and %(foo).  Needs both a ledger-buf and the report

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -633,21 +633,19 @@ to `ledger-binary-path' between runs are honored."
 
 (ert-deftest ledger-report/redo-runs-in-report-buffer ()
   "`ledger-report-redo' rebuilds the report from `ledger-report-cmd'."
-  (let ((rbuf (get-buffer-create ledger-report-buffer-name))
-        (calls 0))
-    (unwind-protect
-        (with-current-buffer rbuf
-          (ledger-report-mode)
-          (setq-local ledger-report-cmd "ledger bal")
-          (setq-local ledger-report-name "X")
-          (setq-local ledger-report-is-reversed nil)
-          (cl-letf (((symbol-function 'shell-command-to-string)
-                     (lambda (_cmd) (cl-incf calls) "out\n"))
-                    ((symbol-function 'pop-to-buffer)
-                     (lambda (b &rest _) (set-buffer b) b)))
-            (ledger-report-redo)
-            (should (>= calls 1))))
-      (let ((kill-buffer-query-functions nil)) (kill-buffer rbuf)))))
+  (let ((calls 0))
+    (ledger-tests-with-temp-file ""
+      (add-to-list 'ledger-reports '("temp-report-for-testing" "zzzzz"))
+      (ledger-report "temp-report-for-testing" nil)
+      (cl-letf (((symbol-function 'shell-command-to-string)
+                 (lambda (cmd)
+                   (should (equal cmd "zzzzz"))
+                   (cl-incf calls)
+                   "out\n")))
+        (should (eq major-mode 'ledger-mode))
+        (ledger-report-redo)
+        (should (equal calls 1)))
+      (kill-buffer ledger-report-buffer-name))))
 
 (ert-deftest ledger-report/main-runs-end-to-end ()
   "Drive the main `ledger-report' entry point through a synthetic command."

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -701,7 +701,6 @@ to `ledger-binary-path' between runs are honored."
 (ert-deftest ledger-report/redo-after-killed-source-buffer ()
   "Do not refresh report if the source buffer has been killed."
   :tags '(report regress)
-  :expected-result :failed
   (let (ledger-buf
         (reports-run 0))
     (ledger-tests-with-temp-file demo-ledger

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -96,7 +96,9 @@ provided (e.g., if BODY is still inside a minibuffer prompt)."
 (defun ledger-tests-with-temp-file-1 (contents body)
   (let* ((temp-file (make-temp-file "ledger-tests-"))
          (ledger-buffer (find-file-noselect temp-file))
-         (ledger-init-file-name nil))
+         (ledger-init-file-name nil)
+         ;; also prevent the ledger binary itself from reading the init file
+         (ledger-exec--args-only t))
     (ledger-tests-reset-custom-values 'ledger)
     (unwind-protect
         (with-current-buffer ledger-buffer

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -109,6 +109,10 @@ provided (e.g., if BODY is still inside a minibuffer prompt)."
         (with-current-buffer ledger-buffer
           (set-buffer-modified-p nil)
           (kill-buffer)))
+      (when (get-buffer ledger-report-buffer-name)
+        (kill-buffer ledger-report-buffer-name))
+      (when (get-buffer ledger-reconcile-buffer-name)
+        (kill-buffer ledger-reconcile-buffer-name))
       (ledger-tests-reset-custom-values 'ledger)
       (delete-file temp-file))))
 

--- a/tools/run-tests.el
+++ b/tools/run-tests.el
@@ -9,6 +9,11 @@
 
 ;;; Code:
 
+(define-advice ert-select-tests (:filter-return (selected-tests) randomize-order)
+  "Randomize the order of ERT tests to avoid accidental state dependencies."
+  (sort selected-tests
+        (lambda (_ _) (zerop (random 2)))))
+
 (let* ((root (or (getenv "LEDGER_MODE_ROOT") default-directory))
        (test-dir (expand-file-name "test" root)))
   (add-to-list 'load-path root)


### PR DESCRIPTION
1. Remove dependencies on initial conditions before test begins
1. Randomize test order to prevent accidental dependencies
1. Add new regression test for ledger-report redo behavior which broke when I
   was diagnosing a related issue.
1. Do not read user's ledger init file

This should help somewhat with #473.