### PR TITLE
Avoid confusing behavior when ledger-report-auto-refresh is nil

### DIFF
--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -451,7 +451,7 @@ With prefix ARG, decrement by that many instead."
               '(ledger-font-lock-keywords t nil nil nil))
   (add-hook 'font-lock-extend-region-functions #'ledger-fontify-extend-region nil t)
   (add-hook 'completion-at-point-functions #'ledger-complete-at-point nil t)
-  (add-hook 'after-save-hook 'ledger-report-redo nil t)
+  (add-hook 'after-save-hook 'ledger-report-redo-after-save nil t)
 
   (add-hook 'post-command-hook 'ledger-highlight-xact-under-point nil t)
   (add-hook 'before-revert-hook 'ledger-highlight--before-revert nil t)

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -246,7 +246,7 @@ See documentation for the function `ledger-master-file'")
 
 (define-derived-mode ledger-report-mode special-mode "Ledger-Report"
   "A mode for viewing ledger reports."
-  (setq-local revert-buffer-function #'ledger-report-redo)
+  (setq-local revert-buffer-function #'ledger-report--revert-buffer)
   (hack-dir-local-variables-non-file-buffer))
 
 (defconst ledger-report--extra-args-marker "[[ledger-mode-flags]]")
@@ -516,7 +516,7 @@ report was first run."
          (previous-month (ledger-report--shift-month current-month shift)))
     (setq ledger-report-current-month previous-month)
     (ledger-report-cmd ledger-report-name nil)
-    (ledger-report-redo)))
+    (revert-buffer)))
 
 (defun ledger-report--add-links ()
   "Replace file and line annotations with buttons."
@@ -601,31 +601,40 @@ specific posting at point instead."
     (pop-to-buffer rbuf)
     (ledger-report-maybe-shrink-window rbuf)))
 
-(defun ledger-report-redo (&optional _ignore-auto _noconfirm)
-  "Redo the report in the current ledger report buffer.
+(defun ledger-report-redo-after-save ()
+  "If `ledger-report-auto-refresh' is non-nil, redo the report buffer.
+
+This is intended to be added to `after-save-hook' by `ledger-mode'."
+  (when (and ledger-report-auto-refresh
+             (get-buffer ledger-report-buffer-name))
+    (with-current-buffer ledger-report-buffer-name
+      (revert-buffer))))
+
+(defun ledger-report--revert-buffer (&optional _ignore-auto _noconfirm)
+  "Redo the report in the current buffer.
 IGNORE-AUTO and NOCONFIRM are for compatibility with
 `revert-buffer-function' and are currently ignored."
+  (when (buffer-live-p ledger-report-ledger-buf)
+    (setq ledger-report-cursor-line-number (line-number-at-pos))
+    (with-silent-modifications
+      (erase-buffer)
+      (ledger-do-report ledger-report-cmd)
+      (when ledger-report-is-reversed
+        (ledger-report-reverse-lines))
+      (when ledger-report-auto-refresh-sticky-cursor
+        (forward-line (- ledger-report-cursor-line-number 5))))
+    (ledger-report-maybe-shrink-window (current-buffer))
+    (run-hooks 'ledger-report-after-report-hook)))
+
+(defun ledger-report-redo ()
+  "Redo the report in the ledger report buffer."
   (interactive)
   (unless (or (derived-mode-p 'ledger-mode)
               (derived-mode-p 'ledger-report-mode))
     (user-error "Not in a ledger-mode or ledger-report-mode buffer"))
-  (let ((cur-buf (current-buffer)))
-    (when (and ledger-report-auto-refresh
-               (get-buffer ledger-report-buffer-name)
-               (with-current-buffer ledger-report-buffer-name
-                 (buffer-live-p ledger-report-ledger-buf)))
-      (pop-to-buffer (get-buffer ledger-report-buffer-name))
-      (setq ledger-report-cursor-line-number (line-number-at-pos))
-      (with-silent-modifications
-        (erase-buffer)
-        (ledger-do-report ledger-report-cmd)
-        (when ledger-report-is-reversed
-          (ledger-report-reverse-lines))
-        (when ledger-report-auto-refresh-sticky-cursor
-          (forward-line (- ledger-report-cursor-line-number 5))))
-      (ledger-report-maybe-shrink-window (current-buffer))
-      (run-hooks 'ledger-report-after-report-hook)
-      (pop-to-buffer cur-buf))))
+  (when (get-buffer ledger-report-buffer-name)
+    (with-current-buffer ledger-report-buffer-name
+      (revert-buffer))))
 
 (defun ledger-report-quit ()
   "Quit the ledger report buffer and kill its buffer."
@@ -644,8 +653,11 @@ IGNORE-AUTO and NOCONFIRM are for compatibility with
 (defun ledger-report-edit-report ()
   "Edit the current report command in the mini buffer and re-run the report."
   (interactive)
-  (setq ledger-report-cmd (ledger-report-read-command ledger-report-cmd))
-  (ledger-report-redo))
+  (unless (derived-mode-p 'ledger-report-mode)
+    (user-error "Not a ledger report buffer"))
+  (with-current-buffer ledger-report-buffer-name
+    (setq ledger-report-cmd (ledger-report-read-command ledger-report-cmd))
+    (revert-buffer)))
 
 (define-obsolete-function-alias 'ledger-report-select-report #'ledger-report "ledger 4.0.0")
 
@@ -703,7 +715,7 @@ IGNORE-AUTO and NOCONFIRM are for compatibility with
         (setq ledger-report-cmd (replace-match "" nil nil ledger-report-cmd))
       (setq ledger-report-cmd (concat ledger-report-cmd
                                       " --exchange " ledger-reconcile-default-commodity))))
-  (ledger-report-redo))
+  (revert-buffer))
 
 (provide 'ledger-report)
 

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -201,10 +201,11 @@ See documentation for the function `ledger-master-file'")
     (save-excursion
       (reverse-region (point) (point-max)))))
 
-(defun ledger-report-maybe-shrink-window ()
-  "Shrink window if `ledger-report-resize-window' is non-nil."
+(defun ledger-report-maybe-shrink-window (buf)
+  "Shrink window displaying BUF if `ledger-report-resize-window' is non-nil."
   (when ledger-report-resize-window
-    (shrink-window-if-larger-than-buffer)))
+    (when-let* ((w (get-buffer-window buf)))
+      (shrink-window-if-larger-than-buffer w))))
 
 (defvar ledger-report-mode-map
   (let ((map (make-sparse-keymap)))
@@ -321,7 +322,7 @@ used to generate the buffer, navigating the buffer, etc."
       (with-silent-modifications
         (erase-buffer)
         (ledger-do-report ledger-report-cmd))
-      (ledger-report-maybe-shrink-window)
+      (ledger-report-maybe-shrink-window (current-buffer))
       (run-hooks 'ledger-report-after-report-hook)
       (message (substitute-command-keys (concat "\\[ledger-report-quit] to quit; "
                                                 "\\[ledger-report-redo] to redo; "
@@ -598,7 +599,7 @@ specific posting at point instead."
     (if (not rbuf)
         (error "There is no ledger report buffer"))
     (pop-to-buffer rbuf)
-    (ledger-report-maybe-shrink-window)))
+    (ledger-report-maybe-shrink-window rbuf)))
 
 (defun ledger-report-redo (&optional _ignore-auto _noconfirm)
   "Redo the report in the current ledger report buffer.
@@ -622,7 +623,7 @@ IGNORE-AUTO and NOCONFIRM are for compatibility with
           (ledger-report-reverse-lines))
         (when ledger-report-auto-refresh-sticky-cursor
           (forward-line (- ledger-report-cursor-line-number 5))))
-      (ledger-report-maybe-shrink-window)
+      (ledger-report-maybe-shrink-window (current-buffer))
       (run-hooks 'ledger-report-after-report-hook)
       (pop-to-buffer cur-buf))))
 

--- a/ledger-report.el
+++ b/ledger-report.el
@@ -614,7 +614,6 @@ IGNORE-AUTO and NOCONFIRM are for compatibility with
                (with-current-buffer ledger-report-buffer-name
                  (buffer-live-p ledger-report-ledger-buf)))
       (pop-to-buffer (get-buffer ledger-report-buffer-name))
-      (ledger-report-maybe-shrink-window)
       (setq ledger-report-cursor-line-number (line-number-at-pos))
       (with-silent-modifications
         (erase-buffer)
@@ -623,6 +622,7 @@ IGNORE-AUTO and NOCONFIRM are for compatibility with
           (ledger-report-reverse-lines))
         (when ledger-report-auto-refresh-sticky-cursor
           (forward-line (- ledger-report-cursor-line-number 5))))
+      (ledger-report-maybe-shrink-window)
       (run-hooks 'ledger-report-after-report-hook)
       (pop-to-buffer cur-buf))))
 

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -518,24 +518,24 @@ https://github.com/ledger/ledger-mode/issues/424"
   :tags '(report regress)
 
   (ledger-tests-with-temp-file demo-ledger
-                               (let ((ledger-reports
-                                      (cons '("dummy-report-name"
-                                              "%(binary) -f %(ledger-file) reg --strict --period %(month) %(account)")
-                                            ledger-reports))
-                                     (ledger-report-format-specifiers
-                                      (cl-list* '("account" . report-test--dummy-format-specifier)
-                                                ledger-report-format-specifiers))
-                                     (report-test--account-format-specifier-called-p nil))
-                                 (ledger-report "dummy-report-name" nil)
-                                 (should report-test--account-format-specifier-called-p)
-                                 ;; `ledger-report-cmd' keeps the raw template so format specifiers
-                                 ;; are re-evaluated on every run, letting saved reports respect
-                                 ;; later changes to `ledger-binary-path' and the current ledger
-                                 ;; file (issue ledger/ledger#1172).
-                                 (should (equal (buffer-local-value
-                                                 'ledger-report-cmd
-                                                 (get-buffer ledger-report-buffer-name))
-                                                "%(binary) -f %(ledger-file) reg --strict --period %(month) %(account)")))))
+    (let ((ledger-reports
+           (cons '("dummy-report-name"
+                   "%(binary) -f %(ledger-file) reg --strict --period %(month) %(account)")
+                 ledger-reports))
+          (ledger-report-format-specifiers
+           (cl-list* '("account" . report-test--dummy-format-specifier)
+                     ledger-report-format-specifiers))
+          (report-test--account-format-specifier-called-p nil))
+      (ledger-report "dummy-report-name" nil)
+      (should report-test--account-format-specifier-called-p)
+      ;; `ledger-report-cmd' keeps the raw template so format specifiers
+      ;; are re-evaluated on every run, letting saved reports respect
+      ;; later changes to `ledger-binary-path' and the current ledger
+      ;; file (issue ledger/ledger#1172).
+      (should (equal (buffer-local-value
+                      'ledger-report-cmd
+                      (get-buffer ledger-report-buffer-name))
+                     "%(binary) -f %(ledger-file) reg --strict --period %(month) %(account)")))))
 
 (ert-deftest ledger-report/binary-path-not-baked-in ()
   "Regression test for ledger/ledger#1172.
@@ -550,19 +550,19 @@ so changes to `ledger-binary-path' take effect on subsequent runs."
                  "%(binary) -f %(ledger-file) bal"))
               ((symbol-function 'ledger-do-report) #'ignore))
       (ledger-tests-with-temp-file demo-ledger
-                                   (let ((ledger-binary-path "ledger-initial"))
-                                     (ledger-report unique-name nil))
-                                   ;; The saved command must still contain the raw %(binary)
-                                   ;; specifier rather than the expanded "ledger-initial" path.
-                                   (let ((saved-cmd (car (cdr (assoc unique-name ledger-reports)))))
-                                     (should saved-cmd)
-                                     (should (string-match-p (regexp-quote "%(binary)") saved-cmd))
-                                     (should-not (string-match-p "ledger-initial" saved-cmd)))
-                                   ;; The buffer-local command is likewise the raw template.
-                                   (should (equal (buffer-local-value
-                                                   'ledger-report-cmd
-                                                   (get-buffer ledger-report-buffer-name))
-                                                  "%(binary) -f %(ledger-file) bal"))))))
+        (let ((ledger-binary-path "ledger-initial"))
+          (ledger-report unique-name nil))
+        ;; The saved command must still contain the raw %(binary)
+        ;; specifier rather than the expanded "ledger-initial" path.
+        (let ((saved-cmd (car (cdr (assoc unique-name ledger-reports)))))
+          (should saved-cmd)
+          (should (string-match-p (regexp-quote "%(binary)") saved-cmd))
+          (should-not (string-match-p "ledger-initial" saved-cmd)))
+        ;; The buffer-local command is likewise the raw template.
+        (should (equal (buffer-local-value
+                        'ledger-report-cmd
+                        (get-buffer ledger-report-buffer-name))
+                       "%(binary) -f %(ledger-file) bal"))))))
 
 (ert-deftest ledger-report/binary-path-expansion-dynamic ()
   "Regression test for ledger/ledger#1172.
@@ -571,16 +571,16 @@ invocation of `ledger-report-expand-format-specifiers', so updates
 to `ledger-binary-path' between runs are honored."
   :tags '(report regress)
   (ledger-tests-with-temp-file demo-ledger
-                               (let ((ledger-report-ledger-buf (current-buffer))
-                                     (template "%(binary) -f %(ledger-file) bal"))
-                                 (let ((ledger-binary-path "first-ledger"))
-                                   (should (string-match-p
-                                            "first-ledger"
-                                            (ledger-report-expand-format-specifiers template))))
-                                 (let ((ledger-binary-path "second-ledger"))
-                                   (let ((expanded (ledger-report-expand-format-specifiers template)))
-                                     (should (string-match-p "second-ledger" expanded))
-                                     (should-not (string-match-p "first-ledger" expanded)))))))
+    (let ((ledger-report-ledger-buf (current-buffer))
+          (template "%(binary) -f %(ledger-file) bal"))
+      (let ((ledger-binary-path "first-ledger"))
+        (should (string-match-p
+                 "first-ledger"
+                 (ledger-report-expand-format-specifiers template))))
+      (let ((ledger-binary-path "second-ledger"))
+        (let ((expanded (ledger-report-expand-format-specifiers template)))
+          (should (string-match-p "second-ledger" expanded))
+          (should-not (string-match-p "first-ledger" expanded)))))))
 
 
 ;;; Additional fill-in tests for residual gaps -------------------------

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -116,27 +116,21 @@
     (should (string= "2024-4" (ledger-report-month-format-specifier)))))
 
 (ert-deftest ledger-report/expand-format-specifiers ()
-  ;; Substitute %(month) and %(foo).  Needs both a ledger-buf and the report
-  ;; buffer because month-format-specifier-default switches there.
-  ;;
-  ;; `src-buf' can be an arbitrary buffer here.
-  (let ((src-buf (current-buffer)))
-    (unwind-protect
-        (with-current-buffer (get-buffer-create ledger-report-buffer-name)
-          (ledger-report-mode)
-          (setq ledger-report-current-month '(2024 . 4)
-                ledger-report-ledger-buf src-buf)
-          (let* ((ledger-report-format-specifiers
-                  '(("month" . ledger-report-month-format-specifier)
-                    ("foo" . (lambda () "QUOTED ME"))))
-                 (result (ledger-report-expand-format-specifiers
-                          "ledger -p %(month) reg %(foo)")))
-            (should (string-match-p "ledger -p 2024-4 reg" result))
-            ;; shell-quote-argument escapes the space, so the literal output
-            ;; contains "QUOTED\ ME".
-            (should (string-match-p "QUOTED" result))
-            (should (string-match-p "ME" result))))
-      (kill-buffer ledger-report-buffer-name))))
+  "Substitute %(month) and %(foo)."
+  (ledger-tests-with-temp-file ""
+    (setq ledger-report-format-specifiers
+          '(("month" . ledger-report-month-format-specifier)
+            ("foo" . (lambda () "QUOTED ME")))
+          ledger-reports '(("X" "ledger -p %(month) reg %(foo) -f %(ledger-file)")))
+    (ledger-report "X" nil)
+    (with-current-buffer ledger-report-buffer-name
+      (setq ledger-report-current-month '(2024 . 4))
+      (ledger-report-redo)
+      (should (string-match-p "ledger -p 2024-4 reg" (buffer-string)))
+      ;; shell-quote-argument escapes the space, so the literal output
+      ;; contains "QUOTED\ ME".
+      (should (string-match-p "QUOTED" (buffer-string)))
+      (should (string-match-p "ME" (buffer-string))))))
 
 (ert-deftest ledger-report/expand-format-specifiers-list ()
   ;; A list-returning specifier is space-joined, not shell-quoted.
@@ -236,14 +230,13 @@
   (should-error (ledger-report-quit)))
 
 (ert-deftest ledger-report/edit-report ()
-  ;; ledger-report-edit-report reads a new command and re-runs.
-  (cl-letf (((symbol-function 'read-from-minibuffer)
-             (lambda (&rest _) "ledger reg --weekly"))
-            ((symbol-function 'ledger-report-redo)
-             (lambda (&rest _) (setq ledger-report-cmd ledger-report-cmd))))
-    (let ((ledger-report-cmd "ledger bal"))
-      (ledger-report-edit-report)
-      (should (string= "ledger reg --weekly" ledger-report-cmd)))))
+  (ledger-tests-with-temp-file ""
+    (ledger-report "bal" nil)
+    (with-current-buffer ledger-report-buffer-name
+      (cl-letf (((symbol-function 'read-from-minibuffer)
+                 (lambda (&rest _) "%(binary) reg --weekly -f %(ledger-file)")))
+        (ledger-report-edit-report)
+        (should (string-match-p "reg --weekly -f " (buffer-string)))))))
 
 (ert-deftest ledger-report/edit-reports ()
   ;; Just verifies it dispatches to customize-variable.
@@ -367,44 +360,18 @@
         (should (assoc "NewReport" ledger-reports))))))
 
 (ert-deftest ledger-report/change-month ()
-  ;; Bind ledger-report-ledger-buf to a real buffer for `expand-format-specifiers'.
-  (let ((report-buf (get-buffer-create ledger-report-buffer-name))
-        (src-buf (current-buffer)))
-    (unwind-protect
-        (let ((ledger-report-current-month '(2024 . 5))
-              (ledger-report-name "X")
-              (ledger-report-ledger-buf src-buf)
-              (ledger-reports '(("X" "ledger reg --period %(month)")))
-              (ledger-report-format-specifiers
-               '(("month" . ledger-report-month-format-specifier))))
-          (cl-letf (((symbol-function 'ledger-report-redo) (lambda (&rest _) nil))
-                    ((symbol-function 'ledger-reports-custom-save)
-                     (lambda () nil)))
-            (ledger-report--change-month -1)
-            (should (equal '(2024 . 4) ledger-report-current-month))
-            (ledger-report--change-month 5)
-            (should (equal '(2024 . 9) ledger-report-current-month))))
-      (let ((kill-buffer-query-functions nil)) (kill-buffer report-buf)))))
-
-(ert-deftest ledger-report/previous-and-next-month ()
-  (let ((report-buf (get-buffer-create ledger-report-buffer-name))
-        (src-buf (current-buffer)))
-    (unwind-protect
-        (let ((ledger-report-current-month '(2024 . 6))
-              (ledger-report-name "X")
-              (ledger-report-ledger-buf src-buf)
-              (ledger-reports '(("X" "ledger reg --period %(month)")))
-              (ledger-report-format-specifiers
-               '(("month" . ledger-report-month-format-specifier))))
-          (cl-letf (((symbol-function 'ledger-report-redo) (lambda (&rest _) nil))
-                    ((symbol-function 'ledger-reports-custom-save)
-                     (lambda () nil)))
-            (ledger-report-previous-month)
-            (should (equal '(2024 . 5) ledger-report-current-month))
-            (ledger-report-next-month)
-            (should (equal '(2024 . 6) ledger-report-current-month))))
-      (let ((kill-buffer-query-functions nil)) (kill-buffer report-buf)))))
-
+  (ledger-tests-with-temp-file ""
+    (setq ledger-reports '(("X" "%(binary) reg -f %(ledger-file) --period %(month)")))
+    (ledger-report "X" nil)
+    (with-current-buffer ledger-report-buffer-name
+      (setq ledger-report-current-month '(2024 . 5))
+      (ledger-report-redo)
+      (should (string-match-p "--period 2024-5" (buffer-string)))
+      (ledger-report-next-month)
+      (should (string-match-p "--period 2024-6" (buffer-string)))
+      (dotimes (_ 6)
+        (ledger-report-previous-month))
+      (should (string-match-p "--period 2023-12" (buffer-string))))))
 
 ;;; toggle-default-commodity --------------------------------------------
 
@@ -413,16 +380,15 @@
     (should-error (ledger-report-toggle-default-commodity))))
 
 (ert-deftest ledger-report/toggle-commodity-add ()
-  (with-temp-buffer
-    (ledger-report-mode)
-    (let ((ledger-report-cmd "ledger reg")
-          (ledger-reconcile-default-commodity "USD"))
-      (cl-letf (((symbol-function 'ledger-report-redo) (lambda (&rest _) nil)))
-        (ledger-report-toggle-default-commodity)
-        (should (string-match-p "--exchange USD" ledger-report-cmd))
-        ;; Toggle off again.
-        (ledger-report-toggle-default-commodity)
-        (should-not (string-match-p "--exchange USD" ledger-report-cmd))))))
+  (ledger-tests-with-temp-file ""
+    (setq ledger-reconcile-default-commodity "USD")
+    (ledger-report "reg" nil)
+    (with-current-buffer ledger-report-buffer-name
+      (ledger-report-toggle-default-commodity)
+      (should (string-match-p "--exchange USD" (buffer-string)))
+      ;; Toggle off again.
+      (ledger-report-toggle-default-commodity)
+      (should-not (string-match-p "--exchange USD" (buffer-string))))))
 
 
 ;;; do-report end-to-end (mocked shell) ---------------------------------

--- a/test/report-test.el
+++ b/test/report-test.el
@@ -229,6 +229,10 @@
       (kill-buffer ledger-report-buffer-name)))
   (should-error (ledger-report-quit)))
 
+(ert-deftest ledger-report/edit-report-not-in-mode ()
+  (with-temp-buffer
+    (should-error (ledger-report-edit-report))))
+
 (ert-deftest ledger-report/edit-report ()
   (ledger-tests-with-temp-file ""
     (ledger-report "bal" nil)
@@ -384,6 +388,7 @@
     (setq ledger-reconcile-default-commodity "USD")
     (ledger-report "reg" nil)
     (with-current-buffer ledger-report-buffer-name
+      (should-not (string-match-p "--exchange USD" (buffer-string)))
       (ledger-report-toggle-default-commodity)
       (should (string-match-p "--exchange USD" (buffer-string)))
       ;; Toggle off again.
@@ -711,6 +716,31 @@ to `ledger-binary-path' between runs are honored."
         ;; buffer where it was created.
         (save-buffer)
         (should (= reports-run 2))))))
+
+(ert-deftest ledger-report/sticky-cursor ()
+  "`ledger-report-auto-refresh-sticky-cursor' preserves cursor line"
+  :tags '(report)
+  (ledger-tests-with-temp-file "
+2025-01-01 Foo
+    Expense  $1
+    Asset
+
+2025-01-02 Bar
+    Expense  $1
+    Asset"
+    (save-buffer)
+    (setq ledger-report-auto-refresh-sticky-cursor t)
+    (setq ledger-reports '(("X" "%(binary) -f %(ledger-file) payees")))
+    (ledger-report "X" nil)
+    (with-current-buffer ledger-report-buffer-name
+      (re-search-forward (rx line-start "Bar" line-end))
+      (goto-char (match-beginning 0))
+      (should (equal (buffer-substring (point) (point-max))
+                     "Bar\nFoo\n"))
+      (forward-line)
+      (should (looking-at "Foo"))
+      (ledger-report-redo)
+      (should (looking-at "Foo")))))
 
 (provide 'report-test)
 


### PR DESCRIPTION
This PR required some refactoring of the ledger-report-mode revert logic.
Namely, ledger-report-redo was split into several functions to disentangle its
various use cases.  See the commit messages for more detail.

Fix #270.