### PR TITLE
Replace ledger-get-minibuffer-prompt with built-in format-prompt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,13 @@ jobs:
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}
+    - name: Install compat
+      run: emacs --batch -f package-initialize -f package-refresh-contents --eval "(package-install 'compat)"
 
     - uses: actions/checkout@v6
     - name: Byte compilation
-      run: emacs --eval "(setq byte-compile-error-on-warn t)" -L . --batch -f batch-byte-compile ./*.el
+      # package-activate-all is not available until Emacs 27
+      run: emacs --eval "(setq byte-compile-error-on-warn t)" -L . --batch -f package-initialize -f batch-byte-compile ./*.el
     - name: Tests
       run: nix shell ${{ matrix.ledger_version || 'nixpkgs#ledger' }} --print-build-logs -c make -C test
     # This is currently for information only, since a lot of docstrings need fixing up

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ packages in [MELPA][melpa] or [MELPA Stable][melpa-stable], you'll need to
 add the directory containing `ledger-mode.el` to your `load-path`, and
 then `(require 'ledger-mode)`.
 
+You will also need to have the `compat` package installed, at version 28.1 or
+newer.
+
 Configuring completion
 ======================
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             package-lint
             elisp-autofmt
             undercover
+            compat
           ]
         );
 

--- a/ledger-mode.el
+++ b/ledger-mode.el
@@ -5,7 +5,7 @@
 ;; This file is not part of GNU Emacs.
 
 ;; Version: 4.1.0
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "26.1") (compat "28.1"))
 ;; URL: https://github.com/ledger/ledger-mode
 
 ;; This is free software; you can redistribute it and/or modify it under
@@ -32,6 +32,7 @@
 
 ;;; Code:
 
+(require 'compat)
 (require 'ledger-regex)
 (require 'org)
 (require 'ledger-commodities)
@@ -111,22 +112,15 @@ This uses `org-read-date', which see."
   (ledger-format-date (let ((org-read-date-prefer-future nil))
                         (org-read-date nil t nil prompt))))
 
-(defun ledger-get-minibuffer-prompt (prompt default)
-  "Return a minibuffer prompt string composing PROMPT and DEFAULT."
-  (concat prompt
-          (if default
-              (concat " (" default "): ")
-            ": ")))
-
 (defun ledger-completing-read-with-default (prompt default collection)
   "Return a user-supplied string after PROMPT.
 Use the given DEFAULT, while providing completions from COLLECTION."
-  (completing-read (ledger-get-minibuffer-prompt prompt default)
+  (completing-read (format-prompt prompt default)
                    collection nil nil nil 'ledger-minibuffer-history default))
 
 (defun ledger-read-string-with-default (prompt default)
   "Return user supplied string after PROMPT, or DEFAULT."
-  (read-string (ledger-get-minibuffer-prompt prompt default)
+  (read-string (format-prompt prompt default)
                nil 'ledger-minibuffer-history default))
 
 (defun ledger-display-balance-at-point (&optional arg)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,6 @@
 EMACS ?= emacs
-EMACS_FLAGS = --quick --directory . --directory ..
+# package-activate-all is not available until Emacs 27
+EMACS_FLAGS = --quick --directory . --directory .. -f package-initialize
 EMACS_BATCH = "$(EMACS)" --batch $(EMACS_FLAGS)
 EMACS_INTERACTIVE = "$(EMACS)" $(EMACS_FLAGS)
 

--- a/tools/lint.el
+++ b/tools/lint.el
@@ -18,6 +18,10 @@
 
 ;;; Code:
 
+;; Required for `package-lint' to find installed `compat' package and not warn
+;; about the dependency.
+(package-activate-all)
+
 (require 'package-lint nil t)
 (require 'checkdoc)
 


### PR DESCRIPTION
This introduces a dependency on the `compat` package.  Not sure if the other
maintainers think that might be controversial, but doing so would allow many
other things to take advantage of more modern APIs, and faster, while retaining
compatibility with older Emacs versions.